### PR TITLE
Dívida técnica: conteúdo excedendo tamanho da tela

### DIFF
--- a/src/components/ButtonPrimary.tsx
+++ b/src/components/ButtonPrimary.tsx
@@ -32,7 +32,6 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     justifyContent: "center",
     minHeight: 45,
-    minWidth: 328,
   },
   button: {
     backgroundColor: colors.theme.primary,

--- a/src/components/ButtonSecundary.tsx
+++ b/src/components/ButtonSecundary.tsx
@@ -30,10 +30,10 @@ const styles = StyleSheet.create({
   base: {
     borderColor: colors.theme.primary,
     borderRadius: 8,
-    borderWidth: 3,
+    borderWidth: 2,
     justifyContent: "center",
     minHeight: 45,
-    minWidth: 328,
+    // minWidth: 328,
   },
   button: {
     backgroundColor: colors.basic.background,

--- a/src/components/ButtonSecundary.tsx
+++ b/src/components/ButtonSecundary.tsx
@@ -33,7 +33,6 @@ const styles = StyleSheet.create({
     borderWidth: 2,
     justifyContent: "center",
     minHeight: 45,
-    // minWidth: 328,
   },
   button: {
     backgroundColor: colors.basic.background,

--- a/src/screens/AddPatient.tsx
+++ b/src/screens/AddPatient.tsx
@@ -91,7 +91,8 @@ const styles = StyleSheet.create({
   },
   buttonContainer: {
     flex: 2 / 8,
-    padding: "5%",
+    paddingHorizontal: 16,
+    paddingVertical: 20,
   },
   input: {
     paddingBottom: "10%",

--- a/src/screens/HospitalCode.tsx
+++ b/src/screens/HospitalCode.tsx
@@ -91,8 +91,10 @@ const styles = StyleSheet.create({
   },
   footer: {
     alignContent: "flex-end",
-    bottom: "1%",
     flex: 3,
+    paddingHorizontal: 16,
+    paddingVertical: 20,
+    width: "100%",
   },
   main: {
     alignItems: "center",

--- a/src/screens/HospitalInformation.tsx
+++ b/src/screens/HospitalInformation.tsx
@@ -138,8 +138,7 @@ const styles = StyleSheet.create({
     alignContent: "center",
     justifyContent: "center",
     paddingBottom: 10,
-    paddingLeft: 40,
-    paddingRight: 40,
+    paddingHorizontal: 16,
     paddingTop: 40,
   },
   main: {
@@ -179,8 +178,7 @@ const styles = StyleSheet.create({
   variableButton: {
     alignContent: "center",
     paddingBottom: 60,
-    paddingLeft: 40,
-    paddingRight: 40,
+    paddingHorizontal: 16,
   },
 });
 

--- a/src/screens/HospitalInformation.tsx
+++ b/src/screens/HospitalInformation.tsx
@@ -72,14 +72,10 @@ const HospitalInformation: React.FC<ScreenProps> = ({ navigation }) => {
               source={require("../assets/time-SVG.png")}
             />
           </View>
-          <View style={styles.textHospital}>
-            <Text style={styles.textHospital}>{hospitalName}</Text>
-          </View>
-          <View style={styles.text}>
-            <Text style={styles.text}>
-              Coleta de tempo de atividades hospitalares
-            </Text>
-          </View>
+          <Text style={styles.textHospital}>{hospitalName}</Text>
+          <Text style={styles.text}>
+            Coleta de tempo de atividades hospitalares
+          </Text>
           <View style={styles.iniciateButton}>
             <ButtonPrimary
               title={
@@ -157,22 +153,17 @@ const styles = StyleSheet.create({
     paddingBottom: 20,
   },
   text: {
-    alignContent: "flex-start",
-    alignItems: "flex-start",
     color: colors.text.secondary,
     fontSize: 15,
-    justifyContent: "center",
-    paddingLeft: 20,
+    paddingHorizontal: 16,
+    textAlign: "center",
   },
   textHospital: {
-    alignContent: "center",
-    alignItems: "flex-start",
     color: colors.text.primary,
     fontSize: 20,
     fontWeight: "bold",
-    justifyContent: "center",
     paddingBottom: 1,
-    paddingLeft: 20,
+    paddingHorizontal: 16,
     textAlign: "center",
   },
   variableButton: {


### PR DESCRIPTION
# Primeira tela saindo para fora da margem em alguns devices

Corrige os botões `ButtonPrimary` e `ButtonSecundary`, e seus usos, para que respeitem a largura máxima da tela. Também corrige os paddings desses botões para as bordas: antes 40pts, agora 16pts.

Também ajusta o alinhamento dos textos da tela de início para que fiquem centralizados, e não mais alinhados à direita.

**Autores:** Rafael.

## Checklist

- ✅ funciona em Android
- ✅ (opcional) funciona em iOS
- ✅ interface funciona nos tamanhos de tela suportados (testar em AVD Tablet/Celular)
- ✅ interface segue especificação no Figma
- 🤷‍♀️ passa nos testes funcionais definidos para a tarefa/story
- ✅ documentação atualizada
- ✅ código dentro dos padrões
- ✅ código sem warnings ou erros de linter (rode `npm run lint -- --fix` para ajustar e faça o commit)
-❌ adiciona dependências externas

## Screenshots

**Android:**

![and code](https://user-images.githubusercontent.com/10260864/82631003-d6f06800-9bca-11ea-9697-bf440f2cf108.png)
![and home](https://user-images.githubusercontent.com/10260864/82631006-d788fe80-9bca-11ea-92b3-b8a5295de21f.png)
![and pac](https://user-images.githubusercontent.com/10260864/82631008-d8219500-9bca-11ea-86ee-253556bff1ca.png)

**iOS, iPhone 8:**

![código ios pequeno](https://user-images.githubusercontent.com/10260864/82631193-4e25fc00-9bcb-11ea-8ea1-bcb086509aa7.png)
![home ios pequeno](https://user-images.githubusercontent.com/10260864/82631198-4fefbf80-9bcb-11ea-9a51-59ea2ddcd045.png)
![paciente ios pequeno](https://user-images.githubusercontent.com/10260864/82631202-5120ec80-9bcb-11ea-95c4-3ba4a8038f68.png)

**iOS, iPhone 11 Pro Max:**

![código ios grande](https://user-images.githubusercontent.com/10260864/82631189-4cf4cf00-9bcb-11ea-91a8-cf33abacba65.png)
![home ios grande](https://user-images.githubusercontent.com/10260864/82631195-4ebe9280-9bcb-11ea-956e-6933a28acddc.png)
![paciente ios grande](https://user-images.githubusercontent.com/10260864/82631201-50885600-9bcb-11ea-8c97-be6d41170f8d.png)

## Outras informações

Os botões da tela de atividade não foram ajustados, porque não estarão presentes na versão final dessa tela (estão presentes apenas para testes).

![and ativ](https://user-images.githubusercontent.com/10260864/82631000-d48e0e00-9bca-11ea-857e-6c0a7e1422db.png)
![atividade ios pequeno](https://user-images.githubusercontent.com/10260864/82631293-84fc1200-9bcb-11ea-8e93-fa32c4816aa1.png)

