### PR TITLE
Abrir descrição de atividade ao clicar em um card do Carousel e ao clicar e um item na lista de atividades adicionar no carousel

### DIFF
--- a/src/components/CardRow.tsx
+++ b/src/components/CardRow.tsx
@@ -43,7 +43,7 @@ const CardRow: React.FC<ScreenProps> = ({ data, onPress }) => {
             {data?.map((item, key) => (
               <View key={key}>
                 <TouchableOpacity
-                  key={item.patient + item.activity}
+                  key={item.patient.id + item.activity}
                   style={[
                     styles.viewGeral,
                     selectedCard === key
@@ -60,7 +60,7 @@ const CardRow: React.FC<ScreenProps> = ({ data, onPress }) => {
                       style={styles.imagePadding}
                       source={require("../assets/profile-carousel.png")}
                     />
-                    <Text style={styles.normalText}>{item.patient}</Text>
+                    <Text style={styles.normalText}>{item.patient.name}</Text>
                   </View>
                   <View style={styles.cardInfo}>
                     <Image

--- a/src/components/CardRow.tsx
+++ b/src/components/CardRow.tsx
@@ -15,21 +15,21 @@ import sizes from "../utils/sizes";
 
 export interface ScreenProps {
   data?: CardType[] | undefined;
-  onPress: (card: CardType) => void;
+  onPress: (card: CardType, index: number) => void;
 }
 
 const CardRow: React.FC<ScreenProps> = ({ data, onPress }) => {
   const [selectedCard, setSelectedCard] = useState(0);
 
-  const setBorder = (key: number) => {
+  const setBorder = (index: number) => {
     console.log(`Previous sected card ${selectedCard}`);
-    setSelectedCard(key);
-    console.log(`Current selected card ${key}`);
+    setSelectedCard(index);
+    console.log(`Current selected card ${index}`);
   };
 
   const handlePress = (item: CardType, key: number) => {
     setBorder(key);
-    onPress(item);
+    onPress(item, key);
   };
 
   return (

--- a/src/components/CardRow.tsx
+++ b/src/components/CardRow.tsx
@@ -17,16 +17,21 @@ export type itemType = CardType;
 
 export interface ScreenProps {
   data?: itemType[] | undefined;
+  onPress: (card: CardType) => void;
 }
 
-const CardRow: React.FC<ScreenProps> = ({ data }) => {
+const CardRow: React.FC<ScreenProps> = ({ data, onPress }) => {
   const [selectedCard, setSelectedCard] = useState(0);
 
-  const setBorder = (title: string, key: number) => {
-    console.log(title);
+  const setBorder = (key: number) => {
     console.log(`Previous sected card ${selectedCard}`);
     setSelectedCard(key);
     console.log(`Current selected card ${key}`);
+  };
+
+  const handlePress = (item: CardType, key: number) => {
+    setBorder(key);
+    onPress(item);
   };
 
   return (
@@ -45,7 +50,7 @@ const CardRow: React.FC<ScreenProps> = ({ data }) => {
                       ? styles.borderGreen
                       : styles.borderWhite,
                   ]}
-                  onPress={() => setBorder(item.activity, key)}
+                  onPress={() => handlePress(item, key)}
                 >
                   <View style={styles.cardTitle}>
                     <Text style={styles.boldText}>{item.activity}</Text>

--- a/src/components/CardRow.tsx
+++ b/src/components/CardRow.tsx
@@ -9,18 +9,14 @@ import {
 } from "react-native";
 
 import { Card } from "react-native-elements";
+import { Card as CardType } from "../services/types";
 import colors from "../utils/colors";
 import sizes from "../utils/sizes";
 
-export type itemType = {
-  id: number;
-  patient: string;
-  title: string;
-  time: string;
-};
+export type itemType = CardType;
 
 export interface ScreenProps {
-  data?: itemType[];
+  data?: itemType[] | undefined;
 }
 
 const CardRow: React.FC<ScreenProps> = ({ data }) => {
@@ -40,19 +36,19 @@ const CardRow: React.FC<ScreenProps> = ({ data }) => {
         <View>
           <ScrollView horizontal showsHorizontalScrollIndicator={false}>
             {data?.map((item, key) => (
-              <View key={item.id}>
+              <View key={key}>
                 <TouchableOpacity
-                  key={item.id}
+                  key={item.patient + item.activity}
                   style={[
                     styles.viewGeral,
                     selectedCard === key
                       ? styles.borderGreen
                       : styles.borderWhite,
                   ]}
-                  onPress={() => setBorder(item.title, key)}
+                  onPress={() => setBorder(item.activity, key)}
                 >
                   <View style={styles.cardTitle}>
-                    <Text style={styles.boldText}>{item.title}</Text>
+                    <Text style={styles.boldText}>{item.activity}</Text>
                   </View>
                   <View style={styles.cardInfo}>
                     <Image

--- a/src/components/CardRow.tsx
+++ b/src/components/CardRow.tsx
@@ -35,7 +35,7 @@ const CardRow: React.FC<ScreenProps> = ({ data }) => {
         <View />
         <View>
           <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-            {data?.map((item, key) => (
+            {data?.reverse().map((item, key) => (
               <View key={key}>
                 <TouchableOpacity
                   key={item.patient + item.activity}

--- a/src/containers/Carousel.tsx
+++ b/src/containers/Carousel.tsx
@@ -6,14 +6,15 @@ import colors from "../utils/colors";
 
 export type Props = {
   data: Card[] | undefined;
+  onPress: (card: Card) => void;
 };
 
-const Carousel: React.FC<Props> = ({ data }) => {
+const Carousel: React.FC<Props> = ({ data, onPress }) => {
   return (
     <View style={styles.carouselStyle}>
       <ScrollView>
         <View>
-          <CardRow data={data} />
+          <CardRow data={data} onPress={onPress} />
         </View>
       </ScrollView>
     </View>

--- a/src/containers/Carousel.tsx
+++ b/src/containers/Carousel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
 import { CardRow } from "../components";
 import { Card } from "../services/types";

--- a/src/containers/Carousel.tsx
+++ b/src/containers/Carousel.tsx
@@ -6,7 +6,7 @@ import colors from "../utils/colors";
 
 export type Props = {
   data: Card[] | undefined;
-  onPress: (card: Card) => void;
+  onPress: (card: Card, index: number) => void;
 };
 
 const Carousel: React.FC<Props> = ({ data, onPress }) => {

--- a/src/containers/Carousel.tsx
+++ b/src/containers/Carousel.tsx
@@ -9,7 +9,7 @@ export type Props = {
 };
 
 const Carousel: React.FC<Props> = ({ data }) => {
-  console.log("CARDS", data);
+  console.log("Carousel.tsx CARDS", data);
   return (
     <View style={styles.carouselStyle}>
       <ScrollView>

--- a/src/containers/Carousel.tsx
+++ b/src/containers/Carousel.tsx
@@ -1,49 +1,15 @@
 import React, { useState } from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
 import { CardRow } from "../components";
+import { Card } from "../services/types";
 import colors from "../utils/colors";
 
-let initialData = [
-  {
-    id: 1,
-    patient: "RVRS",
-    title: "Medir pressão ",
-    time: "00:15:37",
-  },
-  {
-    id: 2,
-    patient: "Iniciais",
-    title: "Conferir dados cadastrais ",
-    time: "00:15:37",
-  },
-  {
-    id: 3,
-    patient: "Iniciais",
-    title: "Trocar roupa de cama ",
-    time: "00:15:37",
-  },
-  {
-    id: 4,
-    patient: "Iniciais",
-    title: "Conferir dados cadastrais ",
-    time: "00:15:37",
-  },
-  {
-    id: 5,
-    patient: "Iniciais",
-    title: "Conferir dados cadastrais ",
-    time: "00:15:37",
-  },
-  {
-    id: 6,
-    patient: "Iniciais",
-    title: "Conferir dados cadastrais ",
-    time: "00:15:37",
-  },
-];
+export type Props = {
+  data: Card[] | undefined;
+};
 
-const Carousel: React.FC = () => {
-  const [data, setData] = useState(initialData);
+const Carousel: React.FC<Props> = ({ data }) => {
+  console.log("CARDS", data);
   return (
     <View style={styles.carouselStyle}>
       <ScrollView>

--- a/src/screens/CarouselScreen.tsx
+++ b/src/screens/CarouselScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useLayoutEffect } from "react";
+import React, { useState, useEffect, useLayoutEffect } from "react";
 import { Dimensions, SafeAreaView, StyleSheet, View } from "react-native";
 
 import { StackNavigationProp } from "@react-navigation/stack";
@@ -26,35 +26,81 @@ const CarouselScreen: React.FC<ScreenProps> = ({ route }) => {
   const patient = route?.params?.patientName;
   const activity = route?.params?.activityName;
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     (async () => {
-      console.log("blablabla");
+      console.log("CarouselScreen.tsx blablabla");
       const responseCard = await localStorage.getSession();
       setRole(responseCard?.role?.toString() || "");
-      let complete = data;
+      let complete: Card[] = data;
       let tam = complete.length || 1;
-
-      if (
-        patient &&
-        activity &&
-        complete[tam - 1]?.patient !== patient &&
-        complete[tam - 1]?.activity !== activity
-      ) {
-        let dataCard = {
-          patient,
-          activity,
-          role,
+      console.log("Antes " + complete);
+      if (complete.length == 0) {
+        let dataCard: Card = {
+          patient: "AAA",
+          activity: "BBB",
+          role: "CCC",
           time: "00:00:00",
         };
+        //complete.push(dataCard);
+        complete = [dataCard];
+        console.log("CarouselScreen.tsx Entrou if");
+      } else {
+        let dataCard: Card = {
+          patient: "AAA",
+          activity: "BBB",
+          role: "CCC",
+          time: "00:00:00",
+        };
+        //complete.push(dataCard);
         complete.push(dataCard);
+        console.log("CarouselScreen.tsx Entrou 2 if");
       }
-
-      // nitialData.push(initialData);
+      //let complete: Card[] = [{patient: 1, activity:2, role:2, time:"Teste"}];
 
       setData(complete);
     })();
   }, []);
+  /*  useEffect(() => {
+    async function load(){
+      console.log("CarouselScreen.tsx blablabla");
+      const responseCard = await localStorage.getSession();
+      setRole(responseCard?.role?.toString() || "");
+      //let complete: Card[] = data;
+      let carta: Card = { patient: "1", activity: "2", role: "2", time: "Teste" };
+      let complete: Card[] = [carta];
+      let tam = complete.length || 1;
+      console.log(complete);
+      /*if (( complete.length == 0 )||
+        (patient &&
+        activity &&
+        complete[tam - 1]?.patient !== patient &&
+        complete[tam - 1]?.activity !== activity)
+      ) {
+        let dataCard: Card = {
+          patient: "AAA",
+          activity:"BBB",
+          role: "CCC",
+          time: "00:00:00",
+        };
+        complete.push(dataCard);
+        console.log("CarouselScreen.tsx Entrou if");
+      }
+      //let complete: Card[] = [{patient: 1, activity:2, role:2, time:"Teste"}];
 
+      // nitialData.push(initialData);
+      console.log("Complete: "+complete);
+      return complete;
+      //setData(complete);
+    }
+
+    let newData = load();
+    if(newData != null){
+      console.log(newData);
+      setData(newData);
+    }
+   
+    //setData(newData);
+  });*/
   return (
     <SafeAreaView>
       <View style={styles.body}>

--- a/src/screens/CarouselScreen.tsx
+++ b/src/screens/CarouselScreen.tsx
@@ -53,7 +53,7 @@ const CarouselScreen: React.FC<ScreenProps> = ({ route }) => {
             complete[length - 1]?.activity !== activity) &&
           dataCard.patient
         ) {
-          complete.push(dataCard);
+          complete.unshift(dataCard);
           await localStorage.addCard(dataCard);
         }
       } else {

--- a/src/screens/CarouselScreen.tsx
+++ b/src/screens/CarouselScreen.tsx
@@ -6,7 +6,6 @@ import { Carousel } from "../containers";
 import * as localStorage from "../services/localStorage";
 import { Activity, Patient, Card } from "../services/types";
 import { CardRow } from "../components";
-
 export interface ScreenProps {
   navigation: StackNavigationProp<any, any>;
   route?: { params: { patientName: string; activityName: string } };
@@ -31,32 +30,36 @@ const CarouselScreen: React.FC<ScreenProps> = ({ route }) => {
       console.log("CarouselScreen.tsx blablabla");
       const responseCard = await localStorage.getSession();
       setRole(responseCard?.role?.toString() || "");
-      let complete: Card[] = data;
-      let tam = complete.length || 1;
-      console.log("Antes " + complete);
-      if (complete.length == 0) {
-        let dataCard: Card = {
+      let strComplete = await localStorage.getCards();
+      let complete: Card[];
+      let dataCard: Card;
+      if(strComplete != null){
+      complete= JSON.parse(strComplete);
+      dataCard = {
+        patient: "DDD",
+        activity: "BBB",
+        role: "CCC",
+        time: "00:00:00",
+      };
+      //complete.push(dataCard);
+      
+      complete.push(dataCard);
+    }
+      else {
+        dataCard = {
           patient: "AAA",
           activity: "BBB",
           role: "CCC",
           time: "00:00:00",
         };
         //complete.push(dataCard);
-        complete = [dataCard];
+        complete= [dataCard];
         console.log("CarouselScreen.tsx Entrou if");
-      } else {
-        let dataCard: Card = {
-          patient: "AAA",
-          activity: "BBB",
-          role: "CCC",
-          time: "00:00:00",
-        };
+      } 
         //complete.push(dataCard);
-        complete.push(dataCard);
-        console.log("CarouselScreen.tsx Entrou 2 if");
-      }
+        
       //let complete: Card[] = [{patient: 1, activity:2, role:2, time:"Teste"}];
-
+      await localStorage.addCard(dataCard);
       setData(complete);
     })();
   }, []);

--- a/src/screens/CarouselScreen.tsx
+++ b/src/screens/CarouselScreen.tsx
@@ -1,5 +1,12 @@
 import React, { useState, useEffect } from "react";
-import { Dimensions, SafeAreaView, StyleSheet, Text, View } from "react-native";
+import {
+  Dimensions,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
 
 import { StackNavigationProp } from "@react-navigation/stack";
 import { Carousel } from "../containers";
@@ -70,14 +77,16 @@ const CarouselScreen: React.FC<ScreenProps> = ({ route }) => {
   };
   return (
     <SafeAreaView>
-      <View style={styles.body}>
-        <Carousel
-          data={data}
-          onPress={(item, index) => handlePress(item, index)}
-        />
-        {/* TODO: substituir por card com detalhes do card */}
-        <Text>{JSON.stringify(selectedCard || data[0])}</Text>
-      </View>
+      <ScrollView contentInsetAdjustmentBehavior="automatic">
+        <View style={styles.body}>
+          <Carousel
+            data={data}
+            onPress={(item, index) => handlePress(item, index)}
+          />
+          {/* TODO: substituir por card com detalhes do card */}
+          <Text>{JSON.stringify(selectedCard || data[0])}</Text>
+        </View>
+      </ScrollView>
     </SafeAreaView>
   );
 };

--- a/src/screens/CarouselScreen.tsx
+++ b/src/screens/CarouselScreen.tsx
@@ -1,18 +1,64 @@
-import React from "react";
+import React, { useState, useLayoutEffect } from "react";
 import { Dimensions, SafeAreaView, StyleSheet, View } from "react-native";
 
 import { StackNavigationProp } from "@react-navigation/stack";
 import { Carousel } from "../containers";
+import * as localStorage from "../services/localStorage";
+import { Activity, Patient, Card } from "../services/types";
+import { CardRow } from "../components";
 
 export interface ScreenProps {
   navigation: StackNavigationProp<any, any>;
+  route?: { params: { patientName: string; activityName: string } };
 }
 
-const CarouselScreen: React.FC<ScreenProps> = () => {
+let initialData = [
+  {
+    patient: "RVRS",
+    activity: "Medir pressão ",
+    time: "00:15:37",
+  },
+];
+
+const CarouselScreen: React.FC<ScreenProps> = ({ route }) => {
+  const [data, setData] = useState([] as Card[]);
+  const [role, setRole] = useState("");
+  const patient = route?.params?.patientName;
+  const activity = route?.params?.activityName;
+
+  useLayoutEffect(() => {
+    (async () => {
+      console.log("blablabla");
+      const responseCard = await localStorage.getSession();
+      setRole(responseCard?.role?.toString() || "");
+      let complete = data;
+      let tam = complete.length || 1;
+
+      if (
+        patient &&
+        activity &&
+        complete[tam - 1]?.patient !== patient &&
+        complete[tam - 1]?.activity !== activity
+      ) {
+        let dataCard = {
+          patient,
+          activity,
+          role,
+          time: "00:00:00",
+        };
+        complete.push(dataCard);
+      }
+
+      // nitialData.push(initialData);
+
+      setData(complete);
+    })();
+  }, []);
+
   return (
     <SafeAreaView>
       <View style={styles.body}>
-        <Carousel />
+        <Carousel data={data} />
       </View>
     </SafeAreaView>
   );

--- a/src/screens/CarouselScreen.tsx
+++ b/src/screens/CarouselScreen.tsx
@@ -44,7 +44,7 @@ const CarouselScreen: React.FC<ScreenProps> = ({ route }) => {
       };
 
       if (strComplete !== null) {
-        complete = JSON.parse(strComplete);
+        complete = strComplete;
         const { length } = complete;
 
         // Evitar que insira duas vezes a mesma execução, em sequência

--- a/src/screens/CarouselScreen.tsx
+++ b/src/screens/CarouselScreen.tsx
@@ -64,13 +64,17 @@ const CarouselScreen: React.FC<ScreenProps> = ({ route }) => {
     })();
   }, []);
 
-  const handlePress = (item: Card) => {
+  const handlePress = (item: Card, index: number) => {
     setSelectedCard(item);
+    console.log(`Selected card ${index}`);
   };
   return (
     <SafeAreaView>
       <View style={styles.body}>
-        <Carousel data={data} onPress={(item) => handlePress(item)} />
+        <Carousel
+          data={data}
+          onPress={(item, index) => handlePress(item, index)}
+        />
         {/* TODO: substituir por card com detalhes do card */}
         <Text>{JSON.stringify(selectedCard || data[0])}</Text>
       </View>

--- a/src/screens/CarouselScreen.tsx
+++ b/src/screens/CarouselScreen.tsx
@@ -4,18 +4,18 @@ import { Dimensions, SafeAreaView, StyleSheet, Text, View } from "react-native";
 import { StackNavigationProp } from "@react-navigation/stack";
 import { Carousel } from "../containers";
 import * as localStorage from "../services/localStorage";
-import { Card } from "../services/types";
+import { Card, Patient } from "../services/types";
 
 export interface ScreenProps {
   navigation: StackNavigationProp<any, any>;
-  route?: { params: { patientName: string; activityName: string } };
+  route?: { params: { patientId: string; activityName: string } };
 }
 
 const CarouselScreen: React.FC<ScreenProps> = ({ route }) => {
   const [data, setData] = useState([] as Card[]);
   const [selectedCard, setSelectedCard] = useState(data[0] as Card);
-  const patient = route?.params?.patientName;
   const activity = route?.params?.activityName;
+  const patientId = route?.params?.patientId;
 
   useEffect(() => {
     (async () => {
@@ -31,6 +31,9 @@ const CarouselScreen: React.FC<ScreenProps> = ({ route }) => {
       let strComplete = await localStorage.getCards();
       let complete: Card[];
       let dataCard: Card;
+      let patient: any;
+
+      if (patientId) patient = await localStorage.getPatient(patientId);
 
       dataCard = {
         patient: patient || "",
@@ -65,6 +68,7 @@ const CarouselScreen: React.FC<ScreenProps> = ({ route }) => {
 
   const handlePress = (item: Card) => {
     setSelectedCard(item);
+    console.warn(selectedCard);
   };
   return (
     <SafeAreaView>

--- a/src/screens/CarouselScreen.tsx
+++ b/src/screens/CarouselScreen.tsx
@@ -4,7 +4,7 @@ import { Dimensions, SafeAreaView, StyleSheet, Text, View } from "react-native";
 import { StackNavigationProp } from "@react-navigation/stack";
 import { Carousel } from "../containers";
 import * as localStorage from "../services/localStorage";
-import { Card, Patient } from "../services/types";
+import { Card } from "../services/types";
 
 export interface ScreenProps {
   navigation: StackNavigationProp<any, any>;
@@ -25,7 +25,7 @@ const CarouselScreen: React.FC<ScreenProps> = ({ route }) => {
         sessionCardResponse?.role?.toString() ||
         preferencesCardResponse?.role?.toString();
 
-      // só exibe tecnologia se ela não for a padrão/salva como default
+      // Só exibe tecnologia se ela não for a padrão/salva como default
       const currentTech = sessionCardResponse?.technology?.toString();
 
       let strComplete = await localStorage.getCards();
@@ -54,12 +54,10 @@ const CarouselScreen: React.FC<ScreenProps> = ({ route }) => {
           dataCard.patient
         ) {
           complete.push(dataCard);
-          console.warn("CarouselScreen.tsx Entrou if");
           await localStorage.addCard(dataCard);
         }
       } else {
         complete = [dataCard];
-        console.warn("CarouselScreen.tsx Entrou if");
         await localStorage.addCard(dataCard);
       }
       setData(complete);
@@ -68,13 +66,13 @@ const CarouselScreen: React.FC<ScreenProps> = ({ route }) => {
 
   const handlePress = (item: Card) => {
     setSelectedCard(item);
-    console.warn(selectedCard);
   };
   return (
     <SafeAreaView>
       <View style={styles.body}>
         <Carousel data={data} onPress={(item) => handlePress(item)} />
-        <Text>{JSON.stringify(selectedCard)}</Text>
+        {/* TODO: substituir por card com detalhes do card */}
+        <Text>{JSON.stringify(selectedCard || data[0])}</Text>
       </View>
     </SafeAreaView>
   );

--- a/src/screens/CarouselScreen.tsx
+++ b/src/screens/CarouselScreen.tsx
@@ -1,23 +1,15 @@
-import React, { useState, useEffect, useLayoutEffect } from "react";
+import React, { useState, useEffect } from "react";
 import { Dimensions, SafeAreaView, StyleSheet, View } from "react-native";
 
 import { StackNavigationProp } from "@react-navigation/stack";
 import { Carousel } from "../containers";
 import * as localStorage from "../services/localStorage";
-import { Activity, Patient, Card } from "../services/types";
-import { CardRow } from "../components";
+import { Card } from "../services/types";
+
 export interface ScreenProps {
   navigation: StackNavigationProp<any, any>;
   route?: { params: { patientName: string; activityName: string } };
 }
-
-let initialData = [
-  {
-    patient: "RVRS",
-    activity: "Medir pressão ",
-    time: "00:15:37",
-  },
-];
 
 const CarouselScreen: React.FC<ScreenProps> = ({ route }) => {
   const [data, setData] = useState([] as Card[]);
@@ -33,77 +25,36 @@ const CarouselScreen: React.FC<ScreenProps> = ({ route }) => {
       let strComplete = await localStorage.getCards();
       let complete: Card[];
       let dataCard: Card;
-      if(strComplete != null){
-      complete= JSON.parse(strComplete);
+
       dataCard = {
-        patient: "DDD",
-        activity: "BBB",
-        role: "CCC",
+        patient: patient || "",
+        activity: activity || "",
+        role,
         time: "00:00:00",
       };
-      //complete.push(dataCard);
-      
-      complete.push(dataCard);
-    }
-      else {
-        dataCard = {
-          patient: "AAA",
-          activity: "BBB",
-          role: "CCC",
-          time: "00:00:00",
-        };
-        //complete.push(dataCard);
-        complete= [dataCard];
-        console.log("CarouselScreen.tsx Entrou if");
-      } 
-        //complete.push(dataCard);
-        
-      //let complete: Card[] = [{patient: 1, activity:2, role:2, time:"Teste"}];
-      await localStorage.addCard(dataCard);
+
+      if (strComplete !== null) {
+        complete = JSON.parse(strComplete);
+        let tam = complete.length;
+
+        // Evitar que insira duas vezes a mesma execução, em sequência
+        if (
+          complete[tam - 1]?.patient !== patient &&
+          complete[tam - 1]?.activity !== activity
+        ) {
+          complete.push(dataCard);
+          console.warn("CarouselScreen.tsx Entrou if");
+          await localStorage.addCard(dataCard);
+        }
+      } else {
+        complete = [dataCard];
+        console.warn("CarouselScreen.tsx Entrou if");
+        await localStorage.addCard(dataCard);
+      }
       setData(complete);
     })();
   }, []);
-  /*  useEffect(() => {
-    async function load(){
-      console.log("CarouselScreen.tsx blablabla");
-      const responseCard = await localStorage.getSession();
-      setRole(responseCard?.role?.toString() || "");
-      //let complete: Card[] = data;
-      let carta: Card = { patient: "1", activity: "2", role: "2", time: "Teste" };
-      let complete: Card[] = [carta];
-      let tam = complete.length || 1;
-      console.log(complete);
-      /*if (( complete.length == 0 )||
-        (patient &&
-        activity &&
-        complete[tam - 1]?.patient !== patient &&
-        complete[tam - 1]?.activity !== activity)
-      ) {
-        let dataCard: Card = {
-          patient: "AAA",
-          activity:"BBB",
-          role: "CCC",
-          time: "00:00:00",
-        };
-        complete.push(dataCard);
-        console.log("CarouselScreen.tsx Entrou if");
-      }
-      //let complete: Card[] = [{patient: 1, activity:2, role:2, time:"Teste"}];
 
-      // nitialData.push(initialData);
-      console.log("Complete: "+complete);
-      return complete;
-      //setData(complete);
-    }
-
-    let newData = load();
-    if(newData != null){
-      console.log(newData);
-      setData(newData);
-    }
-   
-    //setData(newData);
-  });*/
   return (
     <SafeAreaView>
       <View style={styles.body}>

--- a/src/screens/ChooseActivity.tsx
+++ b/src/screens/ChooseActivity.tsx
@@ -6,7 +6,7 @@ import {
   View,
   ScrollView,
 } from "react-native";
-import { StackNavigationProp } from "@react-navigation/stack";
+import { CommonActions } from "@react-navigation/native";
 import { BasicList, ButtonPrimary, PatientHeader } from "../components";
 
 import colors from "../utils/colors";
@@ -14,7 +14,7 @@ import * as localStorage from "../services/localStorage";
 import { Activity, Patient } from "../services/types";
 
 export interface ScreenProps {
-  navigation: StackNavigationProp<any, any>;
+  navigation: any;
   route?: { params: { pacient: Patient } };
 }
 
@@ -32,11 +32,20 @@ const PatientScreen: React.FC<ScreenProps> = ({ navigation, route }) => {
   const handleListPress = (index: number) => {
     const activity = activities[index];
     if (activity) {
-      // TODO: ver modo de usar .reset com params
-      navigation.navigate("CarouselScreen", {
-        patientName: patient?.name,
-        activityName: activities[index].name,
-      });
+      navigation.dispatch(
+        CommonActions.reset({
+          index: 0,
+          routes: [
+            {
+              name: "CarouselScreen",
+              params: {
+                patientName: patient?.name,
+                activityName: activity?.name,
+              },
+            },
+          ],
+        })
+      );
     }
   };
 

--- a/src/screens/ChooseActivity.tsx
+++ b/src/screens/ChooseActivity.tsx
@@ -32,7 +32,11 @@ const PatientScreen: React.FC<ScreenProps> = ({ navigation, route }) => {
   const handleListPress = (index: number) => {
     const activity = activities[index];
     if (activity) {
-      navigation.reset({ index: 0, routes: [{ name: "CarouselScreen" }] });
+      // TODO: ver modo de usar .reset com params
+      navigation.navigate("CarouselScreen", {
+        patientName: patient?.name,
+        activityName: activities[index].name,
+      });
     }
   };
 

--- a/src/screens/ChooseActivity.tsx
+++ b/src/screens/ChooseActivity.tsx
@@ -6,7 +6,7 @@ import {
   View,
   ScrollView,
 } from "react-native";
-import { CommonActions } from "@react-navigation/native";
+import { StackNavigationProp } from "@react-navigation/stack";
 import { BasicList, ButtonPrimary, PatientHeader } from "../components";
 
 import colors from "../utils/colors";
@@ -14,7 +14,7 @@ import * as localStorage from "../services/localStorage";
 import { Activity, Patient } from "../services/types";
 
 export interface ScreenProps {
-  navigation: any;
+  navigation: StackNavigationProp<any, any>;
   route?: { params: { pacient: Patient } };
 }
 
@@ -32,20 +32,18 @@ const PatientScreen: React.FC<ScreenProps> = ({ navigation, route }) => {
   const handleListPress = (index: number) => {
     const activity = activities[index];
     if (activity) {
-      navigation.dispatch(
-        CommonActions.reset({
-          index: 0,
-          routes: [
-            {
-              name: "CarouselScreen",
-              params: {
-                patientId: patient?.id,
-                activityName: activity?.name,
-              },
+      navigation.reset({
+        index: 0,
+        routes: [
+          {
+            name: "CarouselScreen",
+            params: {
+              patientId: patient?.id,
+              activityName: activity?.name,
             },
-          ],
-        })
-      );
+          },
+        ],
+      });
     }
   };
 

--- a/src/screens/ChooseActivity.tsx
+++ b/src/screens/ChooseActivity.tsx
@@ -39,7 +39,7 @@ const PatientScreen: React.FC<ScreenProps> = ({ navigation, route }) => {
             {
               name: "CarouselScreen",
               params: {
-                patientName: patient?.name,
+                patientId: patient?.id,
                 activityName: activity?.name,
               },
             },

--- a/src/screens/ChooseTechnology.tsx
+++ b/src/screens/ChooseTechnology.tsx
@@ -38,11 +38,10 @@ const ChooseTechnology: React.FC<ScreenProps> = ({ route, navigation }) => {
   };
 
   const handleListPress = async (index: number) => {
+    await localStorage.saveTechnology(technologies[index].id, isChecked);
     if (route.params?.running) {
-      await localStorage.saveTechnology(technologies[index].id, isChecked);
       navigation.navigate("ChooseRole");
     } else {
-      await localStorage.saveTechnology(technologies[index].id, isChecked);
       navigation.reset({ index: 0, routes: [{ name: "Home" }] });
     }
   };

--- a/src/screens/ListPatient.tsx
+++ b/src/screens/ListPatient.tsx
@@ -12,6 +12,7 @@ import colors from "../utils/colors";
 import { PacientList } from "../containers";
 import { ButtonPlus } from "../components";
 import { Patient } from "../services/types";
+import * as localStorage from "../services/localStorage";
 
 export interface ScreenProps {
   storageResult: Array<Record<string, any>>;
@@ -44,7 +45,6 @@ const ListPatient: React.FC<ScreenProps> = ({ navigation }) => {
   };
 
   const handleListPress = async (item: Patient) => {
-    console.log("selecionado: ", item);
     navigation.navigate("ChooseActivity", { pacient: item });
   };
 

--- a/src/screens/StartScreen.tsx
+++ b/src/screens/StartScreen.tsx
@@ -18,6 +18,9 @@ const StartScreen: React.FC<ScreenProps> = ({ navigation }) => {
     const firstScreen = await appService.startupScreen();
 
     switch (firstScreen) {
+      case "execution":
+        navigation.reset({ index: 0, routes: [{ name: "CarouselScreen" }] });
+        break;
       case "home":
         navigation.reset({ index: 0, routes: [{ name: "Home" }] });
         break;

--- a/src/services/appService.ts
+++ b/src/services/appService.ts
@@ -4,6 +4,7 @@ import {
   getAuth,
   setAccessCode,
   saveData,
+  getCards,
 } from "./localStorage";
 import api from "./API";
 import { Permission } from "./types";
@@ -22,8 +23,9 @@ import { Permission } from "./types";
  * - `home`: tela de início;
  * - `readCode`: tela para informar código de acesso;
  * - `technology`: tela para selecionar tecnologia.
+ * - `CarouselScreen`: tela de execuções de atividades.
  */
-type Screen = "home" | "readCode" | "technology";
+type Screen = "home" | "readCode" | "technology" | "execution";
 
 /**
  * Faz as verificações necessárias ao iniciar o app e retorna um código
@@ -81,8 +83,12 @@ const firstScreenAfterAppStartup = async (): Promise<Screen> => {
 
   const { technology } = await getPreferences();
   const hasTechnology = technology !== null && technology !== undefined;
+  const cards = await getCards();
 
-  return hasTechnology ? "home" : "technology";
+  if (cards) return "execution";
+  if (hasTechnology) return "home";
+
+  return "technology";
 };
 
 /**

--- a/src/services/asyncStorageAdapter.ts
+++ b/src/services/asyncStorageAdapter.ts
@@ -1,5 +1,5 @@
 import { AsyncStorage } from "react-native";
-import { Patient } from "./types";
+import { Patient, Card } from "./types";
 
 /**
  * Funções que facilitam e padronizam o acesso ao AsyncStorage por outras partes da aplicação.
@@ -87,6 +87,58 @@ export const addObjectItem = async (key: string, newItem: Patient) => {
   return true;
 };
 
+export const addCardItem = async (
+  key: string,
+  newItem: Card,
+) => {
+  let list: string | string[] | null = await getItem(key);
+
+  if (list) list = JSON.parse(list ?? "");
+  if (!Array.isArray(list) || !list?.length) list = [];
+
+  list.push(newItem);
+  await setItem(key, JSON.stringify(list));
+
+  return true;
+};
+
+export const setCardItem = async (
+  key: string,
+  newItem: Card,
+  index: number
+) => {
+  let list: string | string[] | null = await getItem(key);
+
+  if (list) list = JSON.parse(list ?? "");
+  if (!Array.isArray(list) || !list?.length) list = [];
+
+  list[index] = newItem;
+  await setItem(key, JSON.stringify(list));
+
+  return true;
+};
+
+export const removeCardItem = async (
+  key: string,
+  index: number
+) => {
+  let list: string | string[] | null = await getItem(key);
+  if (list) list = JSON.parse(list ?? "");
+
+  if (Array.isArray(list) && list.length > 0) list.splice(index, 1);
+  else {
+    console.log(`❌Error removing ${key}[${index}] from AsyncStorage`);
+    return null;
+  }
+  const removed = JSON.parse(list[index]);
+  await setItem(key, JSON.stringify(list));
+  const currentList = await getItem(key);
+  console.log(`✅ ${key}: ${currentList}`);
+
+  return removed;
+};
+
+
 /**
  * Remove objeto do array de objetos informado
  * @param key Chave do array salvo no AsyncStorage
@@ -105,6 +157,7 @@ export const removeObjectItem = async (key: string, index: number) => {
 
   return currentList;
 };
+
 
 /** Limpa todos os dados armazenados pela aplicação (chaves que começam com `"@"`). */
 export const clear = async () => {

--- a/src/services/asyncStorageAdapter.ts
+++ b/src/services/asyncStorageAdapter.ts
@@ -89,13 +89,30 @@ export const addPatientItem = async (key: string, newItem: Patient) => {
 };
 
 /**
- * Adiciona novo objeto no array de objetos informado
+ * Adiciona novo Card no inicio do array de Cards
+ * @param key Chave do array salvo no AsyncStorage
+ * @param newItem Card a ser adicionado
+ */
+export const addCardItem = async (key: string, newItem: Card) => {
+  let list: string | string[] | null = await getItem(key);
+
+  if (list) list = JSON.parse(list ?? "");
+  if (!Array.isArray(list) || !list?.length) list = [];
+
+  list.unshift(newItem);
+  await setItem(key, JSON.stringify(list));
+
+  return true;
+};
+
+/**
+ * Adiciona novo objeto no final do array de objetos informado
  * @param key Chave do array salvo no AsyncStorage
  * @param newItem Objeto a ser adicionado
  */
 export const addObjectItem = async (
   key: string,
-  newItem: OngoingExecution | FinishedExecution | Card
+  newItem: OngoingExecution | FinishedExecution
 ) => {
   let list: string | string[] | null = await getItem(key);
 

--- a/src/services/asyncStorageAdapter.ts
+++ b/src/services/asyncStorageAdapter.ts
@@ -87,10 +87,7 @@ export const addObjectItem = async (key: string, newItem: Patient) => {
   return true;
 };
 
-export const addCardItem = async (
-  key: string,
-  newItem: Card,
-) => {
+export const addCardItem = async (key: string, newItem: Card) => {
   let list: string | string[] | null = await getItem(key);
 
   if (list) list = JSON.parse(list ?? "");
@@ -118,10 +115,7 @@ export const setCardItem = async (
   return true;
 };
 
-export const removeCardItem = async (
-  key: string,
-  index: number
-) => {
+export const removeCardItem = async (key: string, index: number) => {
   let list: string | string[] | null = await getItem(key);
   if (list) list = JSON.parse(list ?? "");
 
@@ -137,7 +131,6 @@ export const removeCardItem = async (
 
   return removed;
 };
-
 
 /**
  * Remove objeto do array de objetos informado
@@ -157,7 +150,6 @@ export const removeObjectItem = async (key: string, index: number) => {
 
   return currentList;
 };
-
 
 /** Limpa todos os dados armazenados pela aplicação (chaves que começam com `"@"`). */
 export const clear = async () => {

--- a/src/services/localStorage.ts
+++ b/src/services/localStorage.ts
@@ -5,8 +5,12 @@ import {
   setObject,
   mergeObject,
   removeObjectItem,
+  addCardItem,
+  setCardItem,
+  removeCardItem,
+  getItem,
 } from "./asyncStorageAdapter";
-import { LocalData, Preferences, Session, Auth, Patient } from "./types";
+import { LocalData, Preferences, Session, Auth, Patient, Card } from "./types";
 
 /**
  * Coordena o armazenamento de informações locais, usando o AsyncStorage.
@@ -115,6 +119,20 @@ export const getPatient = (id: string) => ifIdExists("@patient", id);
 export const removePatient = (index: number) =>
   removeObjectItem("@patient", index);
 
+/** Adiciona a lista de execucoes em andamento salva localmente */
+export const addCard = (newCard: Card) =>
+addCardItem("@Card", newCard);
+
+/** Retorna toda a lista de execucoes em andamento salva localmente */
+export const getCards = () => getItem("@Card");
+
+/** Altera um objeto em dado index na lista de execucoes em andamento salva localmente */
+export const setCard = (newItem: Card, index: number) =>
+setCardItem("@Card", newItem, index);
+
+/** Remove um objeto em dado index na lista de execucoes em andamento salva localmente */
+export const removeCard = (index: number) =>
+removeCardItem("@Card", index);
 /**
  * Salva a tecnologia sendo utilizada pelo usuário no app.
  * @param technology ID da tecnologia selecionada.

--- a/src/services/localStorage.ts
+++ b/src/services/localStorage.ts
@@ -1,4 +1,5 @@
 import {
+  addCardItem,
   addObjectItem,
   addPatientItem,
   getArray,
@@ -51,6 +52,7 @@ import {
 
 /** Funções auxiliares */
 export {
+  addCardItem,
   addObjectItem,
   addPatientItem,
   clear,
@@ -133,7 +135,7 @@ export const removePatient = (index: number) =>
   removeObjectItem("@patient", index);
 
 /** Adiciona a lista de cards salva localmente */
-export const addCard = (newCard: Card) => addObjectItem("@Card", newCard);
+export const addCard = (newCard: Card) => addCardItem("@Card", newCard);
 
 /** Retorna toda a lista de cards salva localmente */
 export const getCards = () => getArray<Card>("@Card");

--- a/src/services/localStorage.ts
+++ b/src/services/localStorage.ts
@@ -120,19 +120,17 @@ export const removePatient = (index: number) =>
   removeObjectItem("@patient", index);
 
 /** Adiciona a lista de execucoes em andamento salva localmente */
-export const addCard = (newCard: Card) =>
-addCardItem("@Card", newCard);
+export const addCard = (newCard: Card) => addCardItem("@Card", newCard);
 
 /** Retorna toda a lista de execucoes em andamento salva localmente */
 export const getCards = () => getItem("@Card");
 
 /** Altera um objeto em dado index na lista de execucoes em andamento salva localmente */
 export const setCard = (newItem: Card, index: number) =>
-setCardItem("@Card", newItem, index);
+  setCardItem("@Card", newItem, index);
 
 /** Remove um objeto em dado index na lista de execucoes em andamento salva localmente */
-export const removeCard = (index: number) =>
-removeCardItem("@Card", index);
+export const removeCard = (index: number) => removeCardItem("@Card", index);
 /**
  * Salva a tecnologia sendo utilizada pelo usuário no app.
  * @param technology ID da tecnologia selecionada.

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -60,5 +60,6 @@ export type Card = {
   patient: string;
   activity: string;
   role?: string;
+  technology?: string;
   time: string;
 };

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -57,7 +57,7 @@ export type Patient = {
 };
 
 export type Card = {
-  patient: string;
+  patient: Patient;
   activity: string;
   role?: string;
   technology?: string;

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -55,3 +55,10 @@ export type Patient = {
   name: string;
   sex: string;
 };
+
+export type Card = {
+  patient: string;
+  activity: string;
+  role?: string;
+  time: string;
+};


### PR DESCRIPTION
# Abrir descrição de atividade ao clicar em um card do Carousel e, ao clicar e um item na lista de atividades, adicionar no carousel

Ao clicar em um item na lista de atividades, deve-se criar uma nova execução de atividade e salvar no Async Storage, também incluindo mais um card no Carousel utilizando função já pronta. Tarefa também inclui a implementação da funcionalidade de quando clicado em algum card do carousel, deve-se abrir o componente de descrição de atividade implementado na tarefa em anexo.

**Autores:** Bruno Marcelino, Bianca Camargo, Micael F.

## Checklist

- ✅ funciona em Android
- 🤷‍♀️ (opcional) funciona em iOS
- ✅ interface funciona nos tamanhos de tela suportados (testar em AVD Tablet/Celular)
- ✅ interface segue especificação no Figma
- 🤷‍♀️ passa nos testes funcionais definidos para a tarefa/story
- 🤷‍♀️ documentação atualizada
- ✅ código dentro dos padrões - Estamos arrumando
- ✅ código sem warnings ou erros de linter (rode `npm run lint -- --fix` para ajustar e faça o commit)
- 🤷‍♀️ adiciona dependências externas (✅/⚠️/❌/🤷‍♀️ aprovadas pelos AGES III)

Legenda:

- ✅: sim (funciona/builda/documentação atualizada/...)
- ⚠️: parcialmente (partes não funcionam/apenas documentação pendente/...)
- ❌: não (não builda/não funciona/não segue padrões/sem documentação/...)
- 🤷‍♀️: não se aplica (não tenho como testar no iOS/não envolve interface/...)

## Observação: ##
O card é inserido no final, mas está sendo listado no início -> fim no carrosel, por enquanto. Mudar comportamento da integração.

## Adicione um screenshot/gif da aplicação após último commit, que seja possível visualizar a alteração
![image](https://user-images.githubusercontent.com/40609384/82764244-c2d38300-9de3-11ea-9e85-a93d5398c981.png)




## Outras informações

Comentários extras...
