### PR TITLE
Integrar com API (online/offline)

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -231,6 +231,8 @@ PODS:
     - ReactCommon/jscallinvoker (= 0.61.5)
   - RNCMaskedView (0.1.7):
     - React
+  - RNDeviceInfo (5.6.0):
+    - React
   - RNGestureHandler (1.6.0):
     - React
   - RNReanimated (1.7.1):
@@ -275,6 +277,7 @@ DEPENDENCIES:
   - ReactCommon/jscallinvoker (from `../node_modules/react-native/ReactCommon`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
+  - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
@@ -343,6 +346,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   RNCMaskedView:
     :path: "../node_modules/@react-native-community/masked-view"
+  RNDeviceInfo:
+    :path: "../node_modules/react-native-device-info"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
   RNReanimated:
@@ -386,6 +391,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: a49a1f42bf8f5acf1c3e297097517c6b3af377ad
   ReactCommon: 198c7c8d3591f975e5431bec1b0b3b581aa1c5dd
   RNCMaskedView: 90dd32f5b786bd562e876e1421ea77c700cbf71e
+  RNDeviceInfo: 23eef94a8911a03ecf5d6c79df71db34091c8f40
   RNGestureHandler: dde546180bf24af0b5f737c8ad04b6f3fa51609a
   RNReanimated: 4e102df74a9674fa943e05f97f3362b6e44d0b48
   RNScreens: b5c0e1b2b04512919e78bd3898e144a157ce2363

--- a/package-lock.json
+++ b/package-lock.json
@@ -8603,6 +8603,11 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-native-device-info": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-native-device-info/-/react-native-device-info-5.6.0.tgz",
+      "integrity": "sha512-1XeTfGVypQyK9lP8PGy3vFctw0EhoX6XrfycPfsgUu+SsMgX+nJXbAg5Qc2gJgeVFMlGZC9FaI+dskufrCzniA=="
+    },
     "react-native-dotenv": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/react-native-dotenv/-/react-native-dotenv-0.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react": "16.9.0",
     "react-native": "0.61.5",
     "react-native-camera": "^3.23.1",
+    "react-native-device-info": "^5.6.0",
     "react-native-dotenv": "^0.2.0",
     "react-native-elements": "^2.0.0",
     "react-native-gesture-handler": "^1.6.0",


### PR DESCRIPTION
Implementa a integração do fluxo de execuções com a lógica online/offline (apenas as funções necessárias para sincronização, sem integrar com a tela de execução de atividades).

**Autores:** Rafael Araujo

## Checklist

- ✅ funciona em Android
- ✅ (opcional) funciona em iOS
- 🤷‍♀️ interface funciona nos tamanhos de tela suportados (testar em AVD Tablet/Celular)
- 🤷‍♀️ interface segue especificação no Figma
- 🤷‍♀️ passa nos testes funcionais definidos para a tarefa/story
- ✅ documentação atualizada
- ✅ código dentro dos padrões
- ✅ código sem warnings ou erros de linter
- ✅ adiciona dependências externas (✅ aprovadas pelos AGES III)

## Outras informações

Parte do fluxo online/offline implementada:

![onoff](https://user-images.githubusercontent.com/10260864/82854237-3c4f9c00-9ede-11ea-92fe-e649e71e2855.png)

Foi usado o package [react-native-device-info](https://www.npmjs.com/package/react-native-device-info) para obter um token único e persistente por device.