### PR TITLE
Remover botões de teste

### DIFF
--- a/src/screens/ChooseActivity.tsx
+++ b/src/screens/ChooseActivity.tsx
@@ -65,12 +65,6 @@ const PatientScreen: React.FC<ScreenProps> = ({ navigation, route }) => {
             data={activities.map((activity) => activity.name)}
             onPress={handleListPress}
           />
-          <ButtonPrimary
-            title="Início"
-            onPress={() => {
-              return navigation.navigate("Home");
-            }} // TODO: remover modificação futuramente, apenas para testes
-          />
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/src/screens/HospitalInformation.tsx
+++ b/src/screens/HospitalInformation.tsx
@@ -94,12 +94,6 @@ const HospitalInformation: React.FC<ScreenProps> = ({ navigation }) => {
               onPress={() => "nothingyet"}
             />
           </View>
-          <View style={styles.iniciateButton}>
-            <ButtonPrimary
-              title="EmptyScreen"
-              onPress={() => navigation.navigate("EmptyScreen")}
-            />
-          </View>
           <View>
             <TouchableOpacity style={styles.outButton} onPress={handleBack}>
               <Text style={styles.outButton}>Sair</Text>


### PR DESCRIPTION
Botões da tela de início (que levava à `EmptyScreen`) e da tela de listagem de atividades (que levava à tela de início) foram removidos.

**Autor:** Rafael Araujo

## Checklist

- ✅ funciona em Android
- ✅ (opcional) funciona em iOS
- 🤷‍♀️ interface funciona nos tamanhos de tela suportados (testar em AVD Tablet/Celular)
- ✅ interface segue especificação no Figma
- 🤷‍♀️ passa nos testes funcionais definidos para a tarefa/story
- 🤷‍♀️ documentação atualizada
- ✅ código dentro dos padrões
- ✅ código sem warnings ou erros de linter
- 🤷‍♀️ adiciona dependências externas

## Como ficou

- Android:

<div>
<img src="https://user-images.githubusercontent.com/10260864/82924433-b457a980-9f52-11ea-8466-cce52699c09b.png" width="40%"/>
<img src="https://user-images.githubusercontent.com/10260864/82924430-b28de600-9f52-11ea-8619-4a3eefd588b0.png" width="40%"/>
</div>

- iOS:

<div>
<img src="https://user-images.githubusercontent.com/10260864/82924461-bcafe480-9f52-11ea-9875-df8fcdcbf67c.png" width="40%"/>
<img src="https://user-images.githubusercontent.com/10260864/82924449-b9b4f400-9f52-11ea-9b5f-9af9323b586e.png" width="40%"/>
</div>

## Outras informações

Apenas os botões de teste presentes no fluxo normal foram removidos; a tela `EmptyScreen` não entra aqui e deve ser removida ao fim do projeto.