### PR TITLE
Adicionar botão para EmptyScreen a partir da tela de execução

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,7 +79,6 @@ const App = () => (
           component={EmptyScreen}
           options={{
             ...baseHeaderStyle,
-            headerShown: false,
           }}
         />
         <Stack.Screen

--- a/src/containers/CardDescription.tsx
+++ b/src/containers/CardDescription.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { Text, View, StyleSheet, Image } from "react-native";
 
+import { useNavigation } from "@react-navigation/native";
 import { Card } from "react-native-elements";
 import colors from "../utils/colors";
 import sizes from "../utils/sizes";
-import { ButtonExecutions } from "../components";
+import { ButtonExecutions, ButtonPrimary } from "../components";
 import { Card as CardType } from "../services/types";
 
 export interface ScreenProps {
@@ -54,6 +55,8 @@ const CardDescription: React.FC<ScreenProps> = ({
       break;
   }
 
+  const navigation = useNavigation();
+
   return (
     <Card containerStyle={styles.cardStyle}>
       <View style={styles.container}>
@@ -88,6 +91,12 @@ const CardDescription: React.FC<ScreenProps> = ({
         </View>
       </View>
       <View style={styles.buttonsWrap}>
+        <View style={styles.buttonsCardDescription}>
+          <ButtonPrimary
+            title="EmptyScreen"
+            onPress={() => navigation.navigate("EmptyScreen")}
+          />
+        </View>
         <View style={styles.buttonsCardDescription}>
           <ButtonExecutions
             onPress={onPress1}


### PR DESCRIPTION
Para apresentação apenas, será revertido depois.

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-05-26 at 23 40 08](https://user-images.githubusercontent.com/10260864/82971920-3fb05980-9faa-11ea-84bd-97f41a3c7edc.png)