### PR TITLE
Atualiza contagens em andamento no evento de `focus`

### DIFF
--- a/src/screens/CarouselScreen.tsx
+++ b/src/screens/CarouselScreen.tsx
@@ -14,6 +14,7 @@ import { StackNavigationProp } from "@react-navigation/stack";
 import moment from "moment";
 import { Carousel, CardDescription } from "../containers";
 import * as localStorage from "../services/localStorage";
+import { updateAllTimers } from "../services/timerFunction";
 import { Card } from "../services/types";
 import colors from "../utils/colors";
 
@@ -28,15 +29,21 @@ const CarouselScreen: React.FC<ScreenProps> = ({ route }) => {
   const activity = route?.params?.activityName;
   const patientId = route?.params?.patientId;
 
-  // TODO: usar estes tempos para incrementar nos cronômetros já iniciados
-  const handleAppstateFocus = () =>
+  // TODO: atualizar cronômetro visual ao voltar para o app
+  // TODO: conferir se as funções de timerFunctions estão incrementando os segundos corretamente
+  const handleAppstateFocus = () => {
     console.warn(
       `Voltou ao app no tempo: ${moment().format("YYYY-MM-DDTHH:mm:ss[Z]ZZ")}`
-    );
+    ); // TODO: remover após integração, apenas para teste
+
+    // atualiza todos os tempos de execuções que estão em andamento
+    updateAllTimers();
+  };
+
   const handleAppstateBlur = () =>
     console.warn(
       `Saiu do app no tempo: ${moment().format("YYYY-MM-DDTHH:mm:ss[Z]ZZ")}`
-    );
+    ); // TODO: remover após integração, apenas para teste
 
   useEffect(() => {
     // Eventos de focus e blur só funcionam para Android

--- a/src/screens/CarouselScreen.tsx
+++ b/src/screens/CarouselScreen.tsx
@@ -44,7 +44,6 @@ const CarouselScreen: React.FC<ScreenProps> = ({ route }) => {
   };
 
   useEffect(() => {
-    // Eventos de focus e blur só funcionam para Android
     AppState.addEventListener("change", handleAppstateChange);
 
     return () => {

--- a/src/screens/CarouselScreen.tsx
+++ b/src/screens/CarouselScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import {
+  AppState,
   Dimensions,
   SafeAreaView,
   ScrollView,
@@ -23,6 +24,17 @@ const CarouselScreen: React.FC<ScreenProps> = ({ route }) => {
   const [selectedCard, setSelectedCard] = useState(data[0] as Card);
   const activity = route?.params?.activityName;
   const patientId = route?.params?.patientId;
+
+  useEffect(() => {
+    console.warn("Teste");
+    AppState.addEventListener("change", handleAppstate); // Focus e blur só funcionam em Android
+
+    return () => {
+      AppState.removeEventListener("change", handleAppstate);
+    };
+  }, []);
+
+  const handleAppstate = () => console.warn(AppState.currentState);
 
   useEffect(() => {
     (async () => {

--- a/src/screens/CarouselScreen.tsx
+++ b/src/screens/CarouselScreen.tsx
@@ -6,7 +6,6 @@ import {
   ScrollView,
   StyleSheet,
   View,
-  AppStateEvent,
 } from "react-native";
 
 import { StackNavigationProp } from "@react-navigation/stack";
@@ -49,10 +48,7 @@ const CarouselScreen: React.FC<ScreenProps> = ({ route }) => {
     AppState.addEventListener("change", handleAppstateChange);
 
     return () => {
-      AppState.removeEventListener(
-        "change" as AppStateEvent,
-        handleAppstateChange
-      );
+      AppState.removeEventListener("change", handleAppstateChange);
     };
   }, []);
 

--- a/src/screens/CarouselScreen.tsx
+++ b/src/screens/CarouselScreen.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from "react";
 import {
   AppState,
   Dimensions,
-  Platform,
   SafeAreaView,
   ScrollView,
   StyleSheet,
@@ -31,38 +30,30 @@ const CarouselScreen: React.FC<ScreenProps> = ({ route }) => {
 
   // TODO: atualizar cronômetro visual ao voltar para o app
   // TODO: conferir se as funções de timerFunctions estão incrementando os segundos corretamente
-  const handleAppstateFocus = () => {
-    console.warn(
-      `Voltou ao app no tempo: ${moment().format("YYYY-MM-DDTHH:mm:ss[Z]ZZ")}`
-    ); // TODO: remover após integração, apenas para teste
+  const handleAppstateChange = () => {
+    if (AppState.currentState === "active") {
+      console.warn(
+        `Voltou ao app no tempo: ${moment().format("YYYY-MM-DDTHH:mm:ss[Z]ZZ")}`
+      ); // TODO: remover após integração, apenas para teste
 
-    // atualiza todos os tempos de execuções que estão em andamento
-    updateAllTimers();
+      // atualiza todos os tempos de execuções que estão em andamento
+      updateAllTimers();
+    } else if (AppState.currentState === "background")
+      console.warn(
+        `Saiu do app no tempo: ${moment().format("YYYY-MM-DDTHH:mm:ss[Z]ZZ")}`
+      ); // TODO: remover após integração, apenas para teste
   };
-
-  const handleAppstateBlur = () =>
-    console.warn(
-      `Saiu do app no tempo: ${moment().format("YYYY-MM-DDTHH:mm:ss[Z]ZZ")}`
-    ); // TODO: remover após integração, apenas para teste
 
   useEffect(() => {
     // Eventos de focus e blur só funcionam para Android
-    if (Platform.OS === "android") {
-      AppState.addEventListener("focus" as AppStateEvent, handleAppstateFocus);
-      AppState.addEventListener("blur" as AppStateEvent, handleAppstateBlur);
+    AppState.addEventListener("change", handleAppstateChange);
 
-      return () => {
-        AppState.removeEventListener(
-          "focus" as AppStateEvent,
-          handleAppstateFocus
-        );
-        AppState.removeEventListener(
-          "blur" as AppStateEvent,
-          handleAppstateBlur
-        );
-      };
-    }
-    return undefined;
+    return () => {
+      AppState.removeEventListener(
+        "change" as AppStateEvent,
+        handleAppstateChange
+      );
+    };
   }, []);
 
   useEffect(() => {

--- a/src/screens/CarouselScreen.tsx
+++ b/src/screens/CarouselScreen.tsx
@@ -2,10 +2,12 @@ import React, { useState, useEffect } from "react";
 import {
   AppState,
   Dimensions,
+  Platform,
   SafeAreaView,
   ScrollView,
   StyleSheet,
   View,
+  AppStateEvent,
 } from "react-native";
 
 import { StackNavigationProp } from "@react-navigation/stack";
@@ -25,16 +27,27 @@ const CarouselScreen: React.FC<ScreenProps> = ({ route }) => {
   const activity = route?.params?.activityName;
   const patientId = route?.params?.patientId;
 
+  const handleAppstateFocus = () => console.warn("FOCUS");
+  const handleAppstateBlur = () => console.warn("BLUR");
+
   useEffect(() => {
-    console.warn("Teste");
-    AppState.addEventListener("change", handleAppstate); // Focus e blur só funcionam em Android
-
-    return () => {
-      AppState.removeEventListener("change", handleAppstate);
-    };
+    if (Platform.OS === "android") {
+      console.warn("Teste");
+      AppState.addEventListener("focus" as AppStateEvent, handleAppstateFocus); // Focus e blur só funcionam em Android
+      AppState.addEventListener("blur" as AppStateEvent, handleAppstateBlur);
+      return () => {
+        AppState.removeEventListener(
+          "focus" as AppStateEvent,
+          handleAppstateFocus
+        );
+        AppState.removeEventListener(
+          "blur" as AppStateEvent,
+          handleAppstateBlur
+        );
+      };
+    }
+    return undefined;
   }, []);
-
-  const handleAppstate = () => console.warn(AppState.currentState);
 
   useEffect(() => {
     (async () => {

--- a/src/screens/CarouselScreen.tsx
+++ b/src/screens/CarouselScreen.tsx
@@ -11,6 +11,7 @@ import {
 } from "react-native";
 
 import { StackNavigationProp } from "@react-navigation/stack";
+import moment from "moment";
 import { Carousel, CardDescription } from "../containers";
 import * as localStorage from "../services/localStorage";
 import { Card } from "../services/types";
@@ -27,14 +28,22 @@ const CarouselScreen: React.FC<ScreenProps> = ({ route }) => {
   const activity = route?.params?.activityName;
   const patientId = route?.params?.patientId;
 
-  const handleAppstateFocus = () => console.warn("FOCUS");
-  const handleAppstateBlur = () => console.warn("BLUR");
+  // TODO: usar estes tempos para incrementar nos cronômetros já iniciados
+  const handleAppstateFocus = () =>
+    console.warn(
+      `Voltou ao app no tempo: ${moment().format("YYYY-MM-DDTHH:mm:ss[Z]ZZ")}`
+    );
+  const handleAppstateBlur = () =>
+    console.warn(
+      `Saiu do app no tempo: ${moment().format("YYYY-MM-DDTHH:mm:ss[Z]ZZ")}`
+    );
 
   useEffect(() => {
+    // Eventos de focus e blur só funcionam para Android
     if (Platform.OS === "android") {
-      console.warn("Teste");
-      AppState.addEventListener("focus" as AppStateEvent, handleAppstateFocus); // Focus e blur só funcionam em Android
+      AppState.addEventListener("focus" as AppStateEvent, handleAppstateFocus);
       AppState.addEventListener("blur" as AppStateEvent, handleAppstateBlur);
+
       return () => {
         AppState.removeEventListener(
           "focus" as AppStateEvent,

--- a/src/screens/EmptyScreen.tsx
+++ b/src/screens/EmptyScreen.tsx
@@ -9,7 +9,7 @@ import {
   cancelExecution,
   pauseExecution,
   finishExecution,
-  updateAll,
+  updateAllTimers,
 } from "../services/timerFunction";
 import { ButtonPrimary, InputText, ButtonExecutions } from "../components";
 
@@ -50,9 +50,9 @@ const EmptyScreen: React.FC<ScreenProps> = () => {
           }} // remover modificação futuramente, apenas para testes
         />
         <ButtonPrimary
-          title="UpdateAll"
+          title="updateAllTimers"
           onPress={() => {
-            updateAll();
+            updateAllTimers();
           }} // remover modificação futuramente, apenas para testes
         />
         <ButtonPrimary

--- a/src/services/timerFunction.ts
+++ b/src/services/timerFunction.ts
@@ -171,28 +171,35 @@ export const finishExecution = async (index: number) => {
   return false;
 };
 
-/** Função responsável por atualizar contagem de toda a lista de execuções correntes.
- * Retorna false se não há execuções para serem atualizadas e true se há
+/** Função responsável por atualizar contagem de toda a lista de execuções em andamento.
+ *  Retorna `false` se não há execuções em andamento e `true` se há.
  */
-export const updateAll = async () => {
-  const strArray = await getOngoingExecutions();
-  if (!strArray || strArray.length === 0) {
+export const updateAllTimers = async () => {
+  let hasOngoingExecution = false;
+  let execution: OngoingExecution;
+
+  const executions: OngoingExecution[] = await getOngoingExecutions();
+  if (!executions || executions.length === 0) {
     console.warn("Não há execuções.");
-    return false;
+    return hasOngoingExecution;
   }
 
-  const arExecutions: OngoingExecution[] = strArray;
-  let execution: OngoingExecution;
-  let isOneRunning = false;
-  for (let i = 0; i < arExecutions.length; i++) {
-    execution = arExecutions[i];
-    if (execution.currentState === ExecutionStatus.Initialized) {
-      execution = addElapsedTime(execution);
-      isOneRunning = true;
+  executions.map((exec, i) => {
+    if (exec.currentState === ExecutionStatus.Initialized) {
+      hasOngoingExecution = true;
+
+      execution = addElapsedTime(exec);
       setOngoingExecution(execution, i);
+
+      // TODO: remover após a integração, só para teste
+      console.warn(
+        `✅ Index atualizado ${execution.elapsedTime} - index: ${i}`
+      );
     }
-  }
-  return isOneRunning;
+    return hasOngoingExecution;
+  });
+
+  return hasOngoingExecution;
 };
 
 /** Recebe tempo em segundos e devolve string formatada corretamente.
@@ -242,6 +249,7 @@ const addElapsedTime = (execution: OngoingExecution) => {
     newElapsedTime
   );
   execution.elapsedTime = newElapsedTime;
+  execution.latestStartTime = pauseTime;
   return execution;
 };
 


### PR DESCRIPTION
# [02] Atualizações de contagem de tempo de acordo com o AppState

Este PR é para essa parte:
- Quando fechar o app ou minimizar salvar os tempos de execução para mostrar o tempo atualizado quando retornar ao app

OBS.: [SERÃO FEITOS EM OUTRO(s) PR)]:

- Atualizar os tempos na tela com base no tempo salvo antes de minimizar e no timestamp que retornou ao app [Edu, Jéssica e Bianca]
- Atualizar os cronômetros visuais

**Autores:** Bianca, Felipe e Jéssica

## Checklist

- ✅ funciona em Android
- ⚠️ (opcional) funciona em iOS - comentários no código
- ✅interface funciona nos tamanhos de tela suportados (testar em AVD Tablet/Celular)
- ✅ interface segue especificação no Figma
- 🤷‍♀️ passa nos testes funcionais definidos para a tarefa/story
- ✅ documentação atualizada
- ✅ código dentro dos padrões
- ✅ código sem warnings ou erros de linter (rode `npm run lint -- --fix` para ajustar e faça o commit)
- 🤷‍♀️ adiciona dependências externas (🤷‍♀️ aprovadas pelos AGES III)

Legenda:

- ✅: sim (funciona/builda/documentação atualizada/...)
- ⚠️: parcialmente (partes não funcionam/apenas documentação pendente/...)
- ❌: não (não builda/não funciona/não segue padrões/sem documentação/...)
- 🤷‍♀️: não se aplica (não tenho como testar no iOS/não envolve interface/...)

## Adicione um screenshot/gif da aplicação após último commit, que seja possível visualizar a alteração

**Testar na tela EmptyScreen: iniciar execuções, sair do app e voltar**

Opcional, mas recomendado.
![image](https://user-images.githubusercontent.com/40609384/83984841-5f7e4080-a90d-11ea-8cab-a746917daf37.png)

