### PR TITLE
[04] Integrar cronometro aos botões da tela de execução.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1416,6 +1416,27 @@
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.36.tgz",
       "integrity": "sha512-7TUK/k2/QGpEAv/BCwSHlYu3NXZhQ9ZwBYpzr9tjlPIL2C5BeGhH3DmVavRx3ZNyELX5TLC91JTz/cen6AAtIQ=="
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+          "dev": true,
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        }
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -1520,6 +1541,29 @@
       "requires": {
         "@types/react": "*",
         "@types/react-native": "*"
+      }
+    },
+    "@types/react-redux": {
+      "version": "7.1.9",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.9.tgz",
+      "integrity": "sha512-mpC0jqxhP4mhmOl3P4ipRsgTgbNofMRXJb08Ms6gekViLj61v1hOZEKWDCyWsdONr6EjEA6ZHXC446wdywDe0w==",
+      "dev": true,
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+          "dev": true,
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        }
       }
     },
     "@types/react-test-renderer": {
@@ -8886,6 +8930,28 @@
         }
       }
     },
+    "react-redux": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.0.tgz",
+      "integrity": "sha512-EvCAZYGfOLqwV7gh849xy9/pt55rJXPwmYvI4lilPM5rUT/1NxuuN59ipdBksRVSvz0KInbPnp4IfoXJXCqiDA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "hoist-non-react-statics": "^3.3.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.9.0"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        }
+      }
+    },
     "react-refresh": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.2.tgz",
@@ -8987,6 +9053,22 @@
       "dev": true,
       "requires": {
         "util.promisify": "^1.0.0"
+      }
+    },
+    "redux": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
+      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+        }
       }
     },
     "reflect.ownkeys": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "react-native-svg": "^12.0.3",
     "react-native-svg-transformer": "^0.14.3",
     "react-native-vector-icons": "^6.6.0",
+    "react-redux": "^7.2.0",
+    "redux": "^4.0.5",
     "rne-modal-tooltip": "gist:b28c003d87c619674def0878473338a0"
   },
   "devDependencies": {
@@ -47,6 +49,7 @@
     "@types/react": "^16.9.25",
     "@types/react-native": "^0.60.25",
     "@types/react-native-vector-icons": "^6.4.5",
+    "@types/react-redux": "^7.1.9",
     "@types/react-test-renderer": "16.9.1",
     "@typescript-eslint/eslint-plugin": "^2.24.0",
     "@typescript-eslint/parser": "^2.24.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,15 @@
 import "react-native-gesture-handler";
 import React from "react";
+import { Provider } from "react-redux";
+
 import { StatusBar, YellowBox } from "react-native";
 import { NavigationContainer } from "@react-navigation/native";
 import {
   createStackNavigator,
   StackNavigationProp,
 } from "@react-navigation/stack";
+import store from "./store";
+
 import { HeaderButton, HeaderSearch } from "./components";
 import {
   AddPatient,
@@ -64,155 +68,157 @@ const App = () => (
       barStyle="light-content"
       backgroundColor={colors.theme.primary}
     />
-    <NavigationContainer>
-      <Stack.Navigator>
-        <Stack.Screen
-          name="Start"
-          component={StartScreen}
-          options={{
-            ...baseHeaderStyle,
-            headerShown: false,
-          }}
-        />
-        <Stack.Screen
-          name="EmptyScreen"
-          component={EmptyScreen}
-          options={{
-            ...baseHeaderStyle,
-          }}
-        />
-        <Stack.Screen
-          name="HospitalCode"
-          component={HospitalCode}
-          options={{
-            title: "Hospital",
-            ...baseHeaderStyle,
-          }}
-        />
-        <Stack.Screen
-          name="AddPatient"
-          component={AddPatient}
-          options={{
-            title: "Novo paciente",
-            ...baseHeaderStyle,
-          }}
-        />
-        <Stack.Screen
-          name="ChooseActivity"
-          component={ChooseActivity}
-          options={{
-            title: "Atividade",
-            ...baseHeaderStyle,
-          }}
-        />
-        <Stack.Screen
-          name="Home"
-          component={HospitalInformation}
-          options={{
-            headerShown: false,
-            ...baseHeaderStyle,
-          }}
-        />
-        <Stack.Screen
-          name="ChooseTechnology"
-          component={ChooseTechnology}
-          options={{
-            title: "Tecnologia",
-            headerTitle: () => (
-              <HeaderSearch
-                title="Tecnologia"
-                style={baseHeaderStyle.headerTitleStyle}
-              />
-            ),
-            ...baseHeaderStyle,
-          }}
-        />
-        <Stack.Screen
-          name="ChooseRole"
-          component={ChooseRole}
-          options={{
-            headerTitle: () => (
-              <HeaderSearch
-                title="Função"
-                style={baseHeaderStyle.headerTitleStyle}
-              />
-            ),
-            ...baseHeaderStyle,
-          }}
-        />
-        <Stack.Screen
-          name="DocList"
-          component={DocList}
-          options={() => ({
-            title: "Tecnologia Padrão",
-            ...baseHeaderStyle,
-          })}
-        />
-        <Stack.Screen
-          name="ListPatient"
-          component={ListPatient}
-          options={({ navigation }) => ({
-            title: "Paciente",
-            headerRight: () => (
-              <HeaderButton
-                iconName="ios-camera"
-                onPress={() => navigation.navigate("SelectPatient")}
-              />
-            ),
-            ...baseHeaderStyle,
-          })}
-        />
-        <Stack.Screen
-          name="ListTechnology"
-          component={ListTechnology}
-          options={() => ({
-            title: "Tecnologia",
-            ...baseHeaderStyle,
-          })}
-        />
-        <Stack.Screen
-          name="NewTechnology"
-          component={AddTechnology}
-          options={{
-            ...baseHeaderStyle,
-            title: "Nova tecnologia",
-          }}
-        />
-        <Stack.Screen
-          name="SelectPatient"
-          component={SelectPatient}
-          options={({ navigation }) => ({
-            title: "Paciente",
-            headerRight: () => (
-              <HeaderButton
-                iconName="ios-list"
-                onPress={() => navigation.navigate("ListPatient")}
-              />
-            ),
-            ...baseHeaderStyle,
-          })}
-        />
-        <Stack.Screen
-          name="CarouselScreen"
-          component={CarouselScreen}
-          options={({ navigation }) => ({
-            headerTitle: () => (
-              <HeaderSearch
-                title="Em execução"
-                style={baseHeaderStyle.headerTitleStyle}
-              />
-            ),
-            headerRight: () => (
-              <HeaderButton
-                iconName="ios-add-circle-outline"
-                onPress={() => addNewProcedure(navigation)}
-              />
-            ),
-            ...baseHeaderStyle,
-          })}
-        />
-      </Stack.Navigator>
-    </NavigationContainer>
+    <Provider store={store}>
+      <NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen
+            name="Start"
+            component={StartScreen}
+            options={{
+              ...baseHeaderStyle,
+              headerShown: false,
+            }}
+          />
+          <Stack.Screen
+            name="EmptyScreen"
+            component={EmptyScreen}
+            options={{
+              ...baseHeaderStyle,
+            }}
+          />
+          <Stack.Screen
+            name="HospitalCode"
+            component={HospitalCode}
+            options={{
+              title: "Hospital",
+              ...baseHeaderStyle,
+            }}
+          />
+          <Stack.Screen
+            name="AddPatient"
+            component={AddPatient}
+            options={{
+              title: "Novo paciente",
+              ...baseHeaderStyle,
+            }}
+          />
+          <Stack.Screen
+            name="ChooseActivity"
+            component={ChooseActivity}
+            options={{
+              title: "Atividade",
+              ...baseHeaderStyle,
+            }}
+          />
+          <Stack.Screen
+            name="Home"
+            component={HospitalInformation}
+            options={{
+              headerShown: false,
+              ...baseHeaderStyle,
+            }}
+          />
+          <Stack.Screen
+            name="ChooseTechnology"
+            component={ChooseTechnology}
+            options={{
+              title: "Tecnologia",
+              headerTitle: () => (
+                <HeaderSearch
+                  title="Tecnologia"
+                  style={baseHeaderStyle.headerTitleStyle}
+                />
+              ),
+              ...baseHeaderStyle,
+            }}
+          />
+          <Stack.Screen
+            name="ChooseRole"
+            component={ChooseRole}
+            options={{
+              headerTitle: () => (
+                <HeaderSearch
+                  title="Função"
+                  style={baseHeaderStyle.headerTitleStyle}
+                />
+              ),
+              ...baseHeaderStyle,
+            }}
+          />
+          <Stack.Screen
+            name="DocList"
+            component={DocList}
+            options={() => ({
+              title: "Tecnologia Padrão",
+              ...baseHeaderStyle,
+            })}
+          />
+          <Stack.Screen
+            name="ListPatient"
+            component={ListPatient}
+            options={({ navigation }) => ({
+              title: "Paciente",
+              headerRight: () => (
+                <HeaderButton
+                  iconName="ios-camera"
+                  onPress={() => navigation.navigate("SelectPatient")}
+                />
+              ),
+              ...baseHeaderStyle,
+            })}
+          />
+          <Stack.Screen
+            name="ListTechnology"
+            component={ListTechnology}
+            options={() => ({
+              title: "Tecnologia",
+              ...baseHeaderStyle,
+            })}
+          />
+          <Stack.Screen
+            name="NewTechnology"
+            component={AddTechnology}
+            options={{
+              ...baseHeaderStyle,
+              title: "Nova tecnologia",
+            }}
+          />
+          <Stack.Screen
+            name="SelectPatient"
+            component={SelectPatient}
+            options={({ navigation }) => ({
+              title: "Paciente",
+              headerRight: () => (
+                <HeaderButton
+                  iconName="ios-list"
+                  onPress={() => navigation.navigate("ListPatient")}
+                />
+              ),
+              ...baseHeaderStyle,
+            })}
+          />
+          <Stack.Screen
+            name="CarouselScreen"
+            component={CarouselScreen}
+            options={({ navigation }) => ({
+              headerTitle: () => (
+                <HeaderSearch
+                  title="Em execução"
+                  style={baseHeaderStyle.headerTitleStyle}
+                />
+              ),
+              headerRight: () => (
+                <HeaderButton
+                  iconName="ios-add-circle-outline"
+                  onPress={() => addNewProcedure(navigation)}
+                />
+              ),
+              ...baseHeaderStyle,
+            })}
+          />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </Provider>
   </>
 );
 

--- a/src/components/CardRow.tsx
+++ b/src/components/CardRow.tsx
@@ -37,7 +37,6 @@ const CardRow: React.FC<ScreenProps> = ({
     toggleCard(item, index);
   };
 
-  // TODO: manter consistência do estado quando adiciona nova atividade ou fecha o app
   const getExecutionState = (state: ExecutionStatus) => {
     switch (state) {
       case ExecutionStatus.Uninitialized:

--- a/src/components/CardRow.tsx
+++ b/src/components/CardRow.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import {
   Text,
   View,
@@ -12,7 +12,7 @@ import { connect } from "react-redux";
 import { Card } from "react-native-elements";
 
 import * as executionActions from "../store/actions/execution";
-import { Card as CardType } from "../services/types";
+import { Card as CardType, ExecutionStatus } from "../services/types";
 import colors from "../utils/colors";
 import sizes from "../utils/sizes";
 
@@ -29,13 +29,26 @@ const CardRow: React.FC<ScreenProps> = ({
 }) => {
   const setBorder = (index: number) => {
     console.log(`Previous sected card ${selectedCardIndex}`);
-    // setSelectedCard(index);
     console.log(`Current selected card ${index}`);
   };
 
   const handlePress = (item: CardType, index: number) => {
     setBorder(index);
     toggleCard(item, index);
+  };
+
+  // TODO: manter consistência do estado quando adiciona nova atividade ou fecha o app
+  const getExecutionState = (state: ExecutionStatus) => {
+    switch (state) {
+      case ExecutionStatus.Uninitialized:
+        return "Não iniciado";
+      case ExecutionStatus.Initialized:
+        return "Cronometrando";
+      case ExecutionStatus.Paused:
+        return "Pausado";
+      default:
+        return "Inválido";
+    }
   };
 
   return (
@@ -71,7 +84,9 @@ const CardRow: React.FC<ScreenProps> = ({
                       style={styles.imagePadding}
                       source={require("../assets/clock-carousel.png")}
                     />
-                    <Text style={styles.normalText}>{item.executionState}</Text>
+                    <Text style={styles.normalText}>
+                      {getExecutionState(item.executionState)}
+                    </Text>
                   </View>
                 </TouchableOpacity>
               </View>

--- a/src/components/CardRow.tsx
+++ b/src/components/CardRow.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import {
   Text,
   View,
@@ -7,29 +7,35 @@ import {
   ScrollView,
   TouchableOpacity,
 } from "react-native";
+import { connect } from "react-redux";
 
 import { Card } from "react-native-elements";
+
+import * as executionActions from "../store/actions/execution";
 import { Card as CardType } from "../services/types";
 import colors from "../utils/colors";
 import sizes from "../utils/sizes";
 
 export interface ScreenProps {
   data?: CardType[] | undefined;
-  onPress: (card: CardType, index: number) => void;
+  selectedCardIndex: number;
+  toggleCard: (card: CardType, index: number) => void;
 }
 
-const CardRow: React.FC<ScreenProps> = ({ data, onPress }) => {
-  const [selectedCard, setSelectedCard] = useState(0);
-
+const CardRow: React.FC<ScreenProps> = ({
+  data,
+  selectedCardIndex,
+  toggleCard,
+}) => {
   const setBorder = (index: number) => {
-    console.log(`Previous sected card ${selectedCard}`);
-    setSelectedCard(index);
+    console.log(`Previous sected card ${selectedCardIndex}`);
+    // setSelectedCard(index);
     console.log(`Current selected card ${index}`);
   };
 
-  const handlePress = (item: CardType, key: number) => {
-    setBorder(key);
-    onPress(item, key);
+  const handlePress = (item: CardType, index: number) => {
+    setBorder(index);
+    toggleCard(item, index);
   };
 
   return (
@@ -41,10 +47,10 @@ const CardRow: React.FC<ScreenProps> = ({ data, onPress }) => {
             {data?.map((item, key) => (
               <View key={key}>
                 <TouchableOpacity
-                  key={item.patient.id + item.activity}
+                  key={item?.patient?.id! + item.activity}
                   style={[
                     styles.viewGeral,
-                    selectedCard === key
+                    selectedCardIndex === key
                       ? styles.borderGreen
                       : styles.borderWhite,
                   ]}
@@ -58,14 +64,14 @@ const CardRow: React.FC<ScreenProps> = ({ data, onPress }) => {
                       style={styles.imagePadding}
                       source={require("../assets/profile-carousel.png")}
                     />
-                    <Text style={styles.normalText}>{item.patient.name}</Text>
+                    <Text style={styles.normalText}>{item?.patient?.name}</Text>
                   </View>
                   <View style={styles.cardInfo}>
                     <Image
                       style={styles.imagePadding}
                       source={require("../assets/clock-carousel.png")}
                     />
-                    <Text style={styles.normalText}>{item.time}</Text>
+                    <Text style={styles.normalText}>{item.executionState}</Text>
                   </View>
                 </TouchableOpacity>
               </View>
@@ -130,4 +136,18 @@ let styles = StyleSheet.create({
   },
 });
 
-export default CardRow;
+const mapStateToProps = (state: {
+  execution: { data: CardType[]; selectedCardIndex: number };
+}) => ({
+  data: state.execution.data,
+  selectedCardIndex: state.execution.selectedCardIndex,
+});
+
+const mapDispatchToProps = (
+  dispatch: (arg0: { type: string; card: CardType; index: number }) => any
+) => ({
+  toggleCard: (item: CardType, index: number) =>
+    dispatch(executionActions.toggleCard(item, index)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(CardRow);

--- a/src/containers/CardDescription.tsx
+++ b/src/containers/CardDescription.tsx
@@ -28,7 +28,7 @@ const CardDescription: React.FC<ScreenProps> = ({
   let buttonText1 = "";
   let buttonText2 = "";
   let buttonText3 = "";
-  console.warn("DESCRIPTION", data);
+
   switch (data?.executionState) {
     case ExecutionStatus.Uninitialized:
       button1 = "start";

--- a/src/containers/CardDescription.tsx
+++ b/src/containers/CardDescription.tsx
@@ -7,11 +7,10 @@ import { Card } from "react-native-elements";
 import colors from "../utils/colors";
 import sizes from "../utils/sizes";
 import { ButtonExecutions, ButtonPrimary } from "../components";
-import { Card as CardType } from "../services/types";
+import { Card as CardType, ExecutionStatus } from "../services/types";
 
 export interface ScreenProps {
   data?: CardType;
-  // state: "uninitialized" | "initialized" | "finished";
   onPress1: () => void;
   onPress2: () => void;
   onPress3?: () => void;
@@ -31,19 +30,19 @@ const CardDescription: React.FC<ScreenProps> = ({
   let buttonText3 = "";
   console.warn("DESCRIPTION", data);
   switch (data?.executionState) {
-    case "uninitialized":
+    case ExecutionStatus.Uninitialized:
       button1 = "start";
       button2 = "cancel";
       buttonText1 = "INICIAR";
       buttonText2 = "REMOVER";
       break;
-    case "initialized":
+    case ExecutionStatus.Initialized:
       button1 = "stop";
       button2 = "cancel";
       buttonText1 = "PARAR";
       buttonText2 = "CANCELAR";
       break;
-    case "paused":
+    case ExecutionStatus.Paused:
       button1 = "finish";
       button2 = "restart";
       button3 = "cancel";

--- a/src/containers/CardDescription.tsx
+++ b/src/containers/CardDescription.tsx
@@ -91,8 +91,7 @@ const CardDescription: React.FC<ScreenProps> = ({
   };
 
   const handlePress2 = () => {
-    if (isActive) toggle();
-    setTime(0);
+    if (!isActive) toggle();
     onPress2();
   };
 

--- a/src/containers/CardDescription.tsx
+++ b/src/containers/CardDescription.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Text, View, StyleSheet, Image } from "react-native";
+import { connect } from "react-redux";
 
 import { useNavigation } from "@react-navigation/native";
 import { Card } from "react-native-elements";
@@ -10,14 +11,13 @@ import { Card as CardType } from "../services/types";
 
 export interface ScreenProps {
   data?: CardType;
-  state: "uninitialized" | "initialized" | "finished";
+  // state: "uninitialized" | "initialized" | "finished";
   onPress1: () => void;
   onPress2: () => void;
   onPress3?: () => void;
 }
 
 const CardDescription: React.FC<ScreenProps> = ({
-  state,
   data,
   onPress1,
   onPress2,
@@ -29,8 +29,8 @@ const CardDescription: React.FC<ScreenProps> = ({
   let buttonText1 = "";
   let buttonText2 = "";
   let buttonText3 = "";
-
-  switch (state) {
+  console.warn("DESCRIPTION", data);
+  switch (data?.executionState) {
     case "uninitialized":
       button1 = "start";
       button2 = "cancel";
@@ -43,7 +43,7 @@ const CardDescription: React.FC<ScreenProps> = ({
       buttonText1 = "PARAR";
       buttonText2 = "CANCELAR";
       break;
-    case "finished":
+    case "paused":
       button1 = "finish";
       button2 = "restart";
       button3 = "cancel";
@@ -69,10 +69,10 @@ const CardDescription: React.FC<ScreenProps> = ({
               style={styles.imagePadding}
               source={require("../assets/profile-carousel.png")}
             />
-            <Text style={styles.normalText}>{data?.patient.name}</Text>
+            <Text style={styles.normalText}>{data?.patient?.name}</Text>
             <Text
               style={styles.patientSubtitle}
-            >{` ${data?.patient.id} | ${data?.patient.sex}`}</Text>
+            >{` ${data?.patient?.id} | ${data?.patient?.sex}`}</Text>
           </View>
           <View style={styles.cardInfo}>
             <Image
@@ -175,4 +175,8 @@ let styles = StyleSheet.create({
   },
 });
 
-export default CardDescription;
+const mapStateToProps = (state: { execution: { selectedCard: CardType } }) => ({
+  data: state.execution.selectedCard,
+});
+
+export default connect(mapStateToProps)(CardDescription);

--- a/src/containers/Carousel.tsx
+++ b/src/containers/Carousel.tsx
@@ -1,20 +1,15 @@
 import React from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
+
 import { CardRow } from "../components";
-import { Card } from "../services/types";
 import colors from "../utils/colors";
 
-export type Props = {
-  data: Card[] | undefined;
-  onPress: (card: Card, index: number) => void;
-};
-
-const Carousel: React.FC<Props> = ({ data, onPress }) => {
+const Carousel = () => {
   return (
     <View style={styles.carouselStyle}>
       <ScrollView>
         <View>
-          <CardRow data={data} onPress={onPress} />
+          <CardRow />
         </View>
       </ScrollView>
     </View>

--- a/src/screens/CarouselScreen.tsx
+++ b/src/screens/CarouselScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect } from "react";
+import React, { useLayoutEffect, useEffect } from "react";
 import {
   Dimensions,
   SafeAreaView,
@@ -51,6 +51,7 @@ export interface ScreenProps {
 const CarouselScreen: React.FC<ScreenProps> = ({
   addCard,
   data,
+  navigation,
   removeCard,
   setCardExecutionSate,
   selectedCardIndex,
@@ -68,7 +69,6 @@ const CarouselScreen: React.FC<ScreenProps> = ({
       const { roleName, role } =
         sessionCardResponse! || preferencesCardResponse!;
 
-      // Só exibe tecnologia se ela não for a padrão/salva como default
       const currentTech = sessionCardResponse?.technology?.toString();
 
       let strComplete = await localStorage.getCards();
@@ -95,9 +95,8 @@ const CarouselScreen: React.FC<ScreenProps> = ({
 
       if (strComplete) {
         complete = strComplete;
-        // complete = data;
-        // const { length } = complete;
 
+        // se é uma nova execução (recebeu patientId por parâmetro), deve inserir no local storage e no carrosel
         if (patientId) {
           const dataCardInfo: CardExecutionType = {
             idPatient: newCard?.patient?.id,
@@ -107,30 +106,20 @@ const CarouselScreen: React.FC<ScreenProps> = ({
 
           complete.unshift(newCard);
           await createExecution(dataCardInfo);
-        }
-
-        await localStorage.addCard(newCard);
-        addCard(complete);
-
-        // Evitar que insira duas vezes a mesma execução, em sequência
-        /* if (
-          (complete[length - 1]?.patient !== patient ||
-            complete[length - 1]?.activity !== activity) &&
-          patient
-        ) {
-          complete.unshift(newCard);
+          await localStorage.addCard(newCard);
           addCard(complete);
-          // await localStorage.addCard(dataCard);
-        } */
-      } /* else {
-        complete = [dataCard];
-        await localStorage.addCard(dataCard);
-      } */
-      // setData(complete);
+        } else if (complete.length) {
+          // se são somente os dados do local storage, deve adicionar somente ao carrosel
+          addCard(complete);
+        }
+      }
     })();
   }, []);
 
   // TODO: redirecionar pra home quando os cards do carrosel forem todos removidos
+  // navigation.reset({ index: 0, routes: [{ name: "Home" }] });
+
+  // TODO: Manter consistência dos estados, quando fechar o app com alguma execução em andamento
 
   const handlePress1 = async () => {
     switch (data[selectedCardIndex].executionState) {

--- a/src/screens/CarouselScreen.tsx
+++ b/src/screens/CarouselScreen.tsx
@@ -38,7 +38,7 @@ export interface ScreenProps {
   navigation: StackNavigationProp<any, any>;
   removeCard: (index: number) => void;
   selectedCardIndex: number;
-  setCardExecutionSate: (newCardExec: string, index: number) => void;
+  setCardExecutionSate: (newCardExec: ExecutionStatus, index: number) => void;
   route?: {
     params: {
       patientId: string;
@@ -60,7 +60,6 @@ const CarouselScreen: React.FC<ScreenProps> = ({
   const activity = route?.params?.activityName;
   const activityId = route?.params?.activityId;
   const patientId = route?.params?.patientId;
-  // const patientId = route?.params?.patientId;
 
   useLayoutEffect(() => {
     (async () => {
@@ -90,7 +89,7 @@ const CarouselScreen: React.FC<ScreenProps> = ({
         technology: currentTech,
         time: "00:00:00",
         // ao inserir uma atividade nova, ela é sempre `uninitialized`
-        executionState: "uninitialized",
+        executionState: ExecutionStatus.Uninitialized,
       };
 
       if (strComplete) {
@@ -123,15 +122,15 @@ const CarouselScreen: React.FC<ScreenProps> = ({
 
   const handlePress1 = async () => {
     switch (data[selectedCardIndex].executionState) {
-      case "uninitialized":
+      case ExecutionStatus.Uninitialized:
         await initializeExecution(selectedCardIndex);
-        setCardExecutionSate("initialized", selectedCardIndex);
+        setCardExecutionSate(ExecutionStatus.Initialized, selectedCardIndex);
         break;
-      case "initialized":
+      case ExecutionStatus.Initialized:
         await pauseExecution(selectedCardIndex);
-        setCardExecutionSate("paused", selectedCardIndex);
+        setCardExecutionSate(ExecutionStatus.Paused, selectedCardIndex);
         break;
-      case "paused":
+      case ExecutionStatus.Paused:
         await finishExecution(selectedCardIndex);
         await localStorage.removeCard(selectedCardIndex);
         removeCard(selectedCardIndex);
@@ -142,7 +141,7 @@ const CarouselScreen: React.FC<ScreenProps> = ({
   };
 
   const handlePress2 = async () => {
-    if (data[selectedCardIndex].executionState !== "paused") {
+    if (data[selectedCardIndex].executionState !== ExecutionStatus.Paused) {
       const removed = await cancelExecution(selectedCardIndex);
       if (removed) {
         await localStorage.removeCard(selectedCardIndex);
@@ -150,7 +149,7 @@ const CarouselScreen: React.FC<ScreenProps> = ({
       }
     } else {
       await initializeExecution(selectedCardIndex);
-      setCardExecutionSate("initialized", selectedCardIndex);
+      setCardExecutionSate(ExecutionStatus.Initialized, selectedCardIndex);
     }
   };
 
@@ -197,13 +196,13 @@ const mapDispatchToProps = (
   dispatch: (arg0: {
     type: string;
     cards?: CardType[];
-    newExecState?: string;
+    newExecState?: ExecutionStatus;
     index?: number;
   }) => any
 ) => ({
   addCard: (items: CardType[]) => dispatch(executionActions.addCard(items)),
   removeCard: (index: number) => dispatch(executionActions.removeCard(index)),
-  setCardExecutionSate: (newExecState: string, index: number) =>
+  setCardExecutionSate: (newExecState: ExecutionStatus, index: number) =>
     dispatch(executionActions.setCardExecutionSate(newExecState, index)),
 });
 

--- a/src/screens/CarouselScreen.tsx
+++ b/src/screens/CarouselScreen.tsx
@@ -57,7 +57,8 @@ const CarouselScreen: React.FC<ScreenProps> = ({
   route,
 }) => {
   const activity = route?.params?.activityName;
-  const { activityId, patientId } = route?.params!;
+  const activityId = route?.params?.activityId;
+  const patientId = route?.params?.patientId;
   // const patientId = route?.params?.patientId;
 
   useLayoutEffect(() => {

--- a/src/screens/CarouselScreen.tsx
+++ b/src/screens/CarouselScreen.tsx
@@ -130,6 +130,8 @@ const CarouselScreen: React.FC<ScreenProps> = ({
     })();
   }, []);
 
+  // TODO: redirecionar pra home quando os cards do carrosel forem todos removidos
+
   const handlePress1 = async () => {
     switch (data[selectedCardIndex].executionState) {
       case "uninitialized":

--- a/src/screens/CarouselScreen.tsx
+++ b/src/screens/CarouselScreen.tsx
@@ -110,18 +110,22 @@ const CarouselScreen: React.FC<ScreenProps> = ({
         }
       }
 
-      console.warn("COMPLETE", complete);
       if (!complete) {
-        console.warn(`aquiiiii ${complete}`);
         navigation.reset({ index: 0, routes: [{ name: "Home" }] });
       }
     })();
   }, []);
 
-  // TODO: Manter consistência dos estados, quando fechar o app com alguma execução em andamento
+  const updateCardExecutionState = async (
+    newExecutionState: ExecutionStatus
+  ) => {
+    const updatedCard = data[selectedCardIndex];
+    updatedCard.executionState = newExecutionState;
+    await localStorage.setCard(updatedCard, selectedCardIndex);
+  };
 
   const removeCardActions = async () => {
-    // removendo os cards da lista do carrosel e do redux
+    // removendo os cards da lista do carrosel e do redux state
     await localStorage.removeCard(selectedCardIndex);
     removeCard(selectedCardIndex);
 
@@ -137,10 +141,12 @@ const CarouselScreen: React.FC<ScreenProps> = ({
     switch (data[selectedCardIndex].executionState) {
       case ExecutionStatus.Uninitialized:
         await initializeExecution(selectedCardIndex);
+        await updateCardExecutionState(ExecutionStatus.Initialized);
         setCardExecutionSate(ExecutionStatus.Initialized, selectedCardIndex);
         break;
       case ExecutionStatus.Initialized:
         await pauseExecution(selectedCardIndex);
+        await updateCardExecutionState(ExecutionStatus.Paused);
         setCardExecutionSate(ExecutionStatus.Paused, selectedCardIndex);
         break;
       case ExecutionStatus.Paused:
@@ -155,20 +161,17 @@ const CarouselScreen: React.FC<ScreenProps> = ({
   const handlePress2 = async () => {
     if (data[selectedCardIndex].executionState !== ExecutionStatus.Paused) {
       const removed = await cancelExecution(selectedCardIndex);
-      if (removed) {
-        await removeCardActions();
-      }
+      if (removed) await removeCardActions();
     } else {
       await initializeExecution(selectedCardIndex);
+      await updateCardExecutionState(ExecutionStatus.Initialized);
       setCardExecutionSate(ExecutionStatus.Initialized, selectedCardIndex);
     }
   };
 
   const handlePress3 = async () => {
     const removed = await cancelExecution(selectedCardIndex);
-    if (removed) {
-      await removeCardActions();
-    }
+    if (removed) await removeCardActions();
   };
 
   return (

--- a/src/screens/CarouselScreen.tsx
+++ b/src/screens/CarouselScreen.tsx
@@ -36,6 +36,7 @@ export interface ScreenProps {
   addCard: (item: CardType[]) => void;
   data: CardType[];
   navigation: StackNavigationProp<any, any>;
+  removeCard: (index: number) => void;
   selectedCardIndex: number;
   setCardExecutionSate: (newCardExec: string, index: number) => void;
   route?: {
@@ -50,6 +51,7 @@ export interface ScreenProps {
 const CarouselScreen: React.FC<ScreenProps> = ({
   addCard,
   data,
+  removeCard,
   setCardExecutionSate,
   selectedCardIndex,
   route,
@@ -130,21 +132,17 @@ const CarouselScreen: React.FC<ScreenProps> = ({
   const handlePress1 = async () => {
     switch (data[selectedCardIndex].executionState) {
       case "uninitialized":
-        console.log("1111111");
         await initializeExecution(selectedCardIndex);
-        console.log("22222222222");
         setCardExecutionSate("initialized", selectedCardIndex);
-        console.log("33333333333");
         break;
       case "initialized":
         await pauseExecution(selectedCardIndex);
         setCardExecutionSate("paused", selectedCardIndex);
         break;
       case "paused":
-        // TODO: no momento só conseguimos remover os cards do início
         await finishExecution(selectedCardIndex);
         await localStorage.removeCard(selectedCardIndex);
-        // TODO action para remover card
+        removeCard(selectedCardIndex);
         break;
       default:
         break;
@@ -156,7 +154,7 @@ const CarouselScreen: React.FC<ScreenProps> = ({
       const removed = await cancelExecution(selectedCardIndex);
       if (removed) {
         await localStorage.removeCard(selectedCardIndex);
-        // TODO action para remover card
+        removeCard(selectedCardIndex);
       }
     } else {
       await initializeExecution(selectedCardIndex);
@@ -168,7 +166,7 @@ const CarouselScreen: React.FC<ScreenProps> = ({
     const removed = await cancelExecution(selectedCardIndex);
     if (removed) {
       await localStorage.removeCard(selectedCardIndex);
-      // TODO action para remover card
+      removeCard(selectedCardIndex);
     }
   };
 
@@ -212,6 +210,7 @@ const mapDispatchToProps = (
   }) => any
 ) => ({
   addCard: (items: CardType[]) => dispatch(executionActions.addCard(items)),
+  removeCard: (index: number) => dispatch(executionActions.removeCard(index)),
   setCardExecutionSate: (newExecState: string, index: number) =>
     dispatch(executionActions.setCardExecutionSate(newExecState, index)),
 });

--- a/src/screens/ChooseActivity.tsx
+++ b/src/screens/ChooseActivity.tsx
@@ -40,6 +40,7 @@ const PatientScreen: React.FC<ScreenProps> = ({ navigation, route }) => {
             params: {
               patientId: patient?.id,
               activityName: activity?.name,
+              activityId: activity?.id,
             },
           },
         ],

--- a/src/screens/ListPatient.tsx
+++ b/src/screens/ListPatient.tsx
@@ -23,13 +23,13 @@ const ListPatient: React.FC<ScreenProps> = ({ navigation }) => {
 
   useEffect(() => {
     async function getStorage() {
-      let pacientData = await getItem("@patient");
-      if (pacientData) {
-        pacientData = JSON.parse(pacientData);
-        if (Array.isArray(pacientData)) setData(pacientData);
+      let patientData = await getItem("@patient");
+      if (patientData) {
+        patientData = JSON.parse(patientData);
+        if (Array.isArray(patientData)) setData(patientData);
       }
 
-      console.log(pacientData);
+      console.log(patientData);
     }
     getStorage();
   }, []);

--- a/src/services/asyncStorageAdapter.ts
+++ b/src/services/asyncStorageAdapter.ts
@@ -120,7 +120,7 @@ export const addObjectItem = async (
   if (list) list = JSON.parse(list ?? "");
   if (!Array.isArray(list) || !list?.length) list = [];
 
-  list.push(newItem);
+  list.unshift(newItem);
   await setItem(key, JSON.stringify(list));
 
   return true;

--- a/src/services/timerFunction.ts
+++ b/src/services/timerFunction.ts
@@ -134,7 +134,9 @@ export const cancelExecution = async (index: number) => {
   const confirmed = await showExecutionAlert("remove");
   if (confirmed) {
     await removeOngoingExecution(index);
+    return true;
   }
+  return false;
 };
 
 /** Função responsável por finalisar uma execução, removendo-a da lista de
@@ -242,6 +244,7 @@ const addElapsedTime = (execution: OngoingExecution) => {
     newElapsedTime
   );
   execution.elapsedTime = newElapsedTime;
+  execution.latestStartTime = pauseTime;
   return execution;
 };
 

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -22,7 +22,7 @@ export type Card = {
   role?: string;
   technology?: string;
   time: string;
-  executionState: "uninitialized" | "initialized" | "paused";
+  executionState: ExecutionStatus;
 };
 
 export type CardExecutionType = {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -17,17 +17,18 @@ export interface Auth {
 }
 
 export type Card = {
-  patient: Patient;
-  activity: string;
+  patient?: Patient;
+  activity?: string;
   role?: string;
   technology?: string;
   time: string;
+  executionState: "uninitialized" | "initialized" | "paused";
 };
 
 export type CardExecutionType = {
-  idPatient: string;
-  role: number;
-  activity: number;
+  idPatient?: string;
+  role?: number;
+  activity?: number;
 };
 
 export type Doc = {

--- a/src/store/actions/execution.ts
+++ b/src/store/actions/execution.ts
@@ -1,4 +1,4 @@
-import { Card as CardType } from "../../services/types";
+import { Card as CardType, ExecutionStatus } from "../../services/types";
 
 /**
  * Sobrescreve os cards do state, pelo novo array com um card novo
@@ -27,7 +27,10 @@ export function removeCard(index: number) {
  * @param newExecState Novo estado de execução do card
  * @param index Índice do card a ser alterado
  */
-export function setCardExecutionSate(newExecState: string, index: number) {
+export function setCardExecutionSate(
+  newExecState: ExecutionStatus,
+  index: number
+) {
   return {
     type: "SET_CARD_EXECUTION_STATE",
     newExecState,

--- a/src/store/actions/execution.ts
+++ b/src/store/actions/execution.ts
@@ -1,0 +1,33 @@
+import { Card as CardType } from "../../services/types";
+
+/**
+ * Subrescreve os cards do state, pelo novo array com um card novo
+ * @param cards Array de cards, com o novo card adicionado
+ */
+export function addCard(cards: CardType[]) {
+  return {
+    type: "ADD_CARD",
+    cards,
+  };
+}
+
+export function setCardExecutionSate(newExecState: string, index: number) {
+  return {
+    type: "SET_CARD_EXECUTION_STATE",
+    newExecState,
+    index,
+  };
+}
+
+/**
+ * Define o card selecionado
+ * @param card Objeto de card com suas respectivas informações
+ * @param index Índice do card selecionado
+ */
+export function toggleCard(card: CardType, index: number) {
+  return {
+    type: "SET_SELECTED_CARD",
+    card,
+    index,
+  };
+}

--- a/src/store/actions/execution.ts
+++ b/src/store/actions/execution.ts
@@ -1,7 +1,7 @@
 import { Card as CardType } from "../../services/types";
 
 /**
- * Subrescreve os cards do state, pelo novo array com um card novo
+ * Sobrescreve os cards do state, pelo novo array com um card novo
  * @param cards Array de cards, com o novo card adicionado
  */
 export function addCard(cards: CardType[]) {
@@ -11,6 +11,22 @@ export function addCard(cards: CardType[]) {
   };
 }
 
+/**
+ * Remove card do carrosel, a partir do índice informado
+ * @param index Índice do card a ser removido
+ */
+export function removeCard(index: number) {
+  return {
+    type: "REMOVE_CARD",
+    index,
+  };
+}
+
+/**
+ * Seta o estado de execução do card, a partir do índice informado
+ * @param newExecState Novo estado de execução do card
+ * @param index Índice do card a ser alterado
+ */
 export function setCardExecutionSate(newExecState: string, index: number) {
   return {
     type: "SET_CARD_EXECUTION_STATE",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,7 @@
+import { createStore } from "redux";
+
+import reducers from "./reducers";
+
+const store = createStore(reducers);
+
+export default store;

--- a/src/store/reducers/execution.ts
+++ b/src/store/reducers/execution.ts
@@ -1,0 +1,53 @@
+/**
+ * Aqui fica o estado global da tela de execuções, ou seja,
+ * todas as informações que são compartilhadas entre os componentes
+ * que participam da execução de atividades.
+ */
+
+const initialState = {
+  selectedCard: {},
+  selectedCardIndex: 0,
+  data: [
+    {
+      patient: { id: "", name: "", sex: "" },
+      activity: "",
+      role: "",
+      technology: "",
+      time: "00:00:00",
+      executionState: "unitialized",
+    },
+  ],
+};
+
+export default function execution(prevState = initialState, action: any) {
+  switch (action.type) {
+    case "ADD_CARD":
+      return {
+        ...prevState,
+        data: action.cards,
+        selectedCard: action.cards[0],
+        selectedCardIndex: 0,
+      };
+    case "SET_CARD_EXECUTION_STATE": {
+      let updatedData = { ...prevState };
+      console.warn("AQUI ", updatedData.data[action.index]);
+      updatedData.data[action.index].executionState = action.newExecState;
+      console.warn("AQUI ", updatedData);
+      return {
+        ...prevState,
+        data: updatedData.data,
+        selectedCard: updatedData.data[action.index],
+        selectedCardIndex: action.index,
+      };
+    }
+    case "SET_SELECTED_CARD":
+      return {
+        ...prevState,
+        selectedCard: action.card,
+        selectedCardIndex: action.index,
+      };
+    default:
+      break;
+  }
+  return prevState;
+}

--- a/src/store/reducers/execution.ts
+++ b/src/store/reducers/execution.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-case-declarations */
 /**
  * Aqui fica o estado global da tela de execuções, ou seja,
  * todas as informações que são compartilhadas entre os componentes
@@ -19,36 +20,37 @@ export type CarouselType = {
 };
 
 export default function execution(prevState = initialState, action: any) {
-  let updatedData;
   switch (action.type) {
     case "ADD_CARD":
       return {
-        ...prevState,
         data: action.cards,
         selectedCard: action.cards[0],
         selectedCardIndex: 0,
       };
     case "REMOVE_CARD":
-      updatedData = prevState.data;
-      updatedData.splice(action.index, 1);
-      console.warn("AHAAM", updatedData);
-      return {
-        data: updatedData,
-        selectedCard: undefined,
-        selectedCardIndex: 0,
-      };
-    case "SET_CARD_EXECUTION_STATE": {
-      updatedData = { ...prevState };
-      console.warn("AQUI ", updatedData.data[action.index]);
-      updatedData.data[action.index].executionState = action.newExecState;
-      console.warn("AQUI ", updatedData);
+      const nextCard = prevState.data.length > 0 && action.index === 0 ? 1 : 0;
       return {
         ...prevState,
-        data: updatedData.data,
-        selectedCard: updatedData.data[action.index],
+        data: prevState.data.filter((item, index) => index !== action.index),
+        selectedCard: prevState.data[nextCard],
+        selectedCardIndex: 0,
+      };
+    case "SET_CARD_EXECUTION_STATE":
+      const data = prevState.data.map((item, index) => {
+        if (index !== action.index) {
+          return item;
+        }
+        return {
+          ...item,
+          executionState: action.newExecState,
+        };
+      });
+
+      return {
+        data,
+        selectedCard: data[action.index],
         selectedCardIndex: action.index,
       };
-    }
     case "SET_SELECTED_CARD":
       return {
         ...prevState,

--- a/src/store/reducers/execution.ts
+++ b/src/store/reducers/execution.ts
@@ -4,19 +4,18 @@
  * que participam da execução de atividades.
  */
 
-const initialState = {
-  selectedCard: {},
+import { Card as CardType } from "src/services/types";
+
+const initialState: CarouselType = {
+  selectedCard: undefined,
   selectedCardIndex: 0,
-  data: [
-    {
-      patient: { id: "", name: "", sex: "" },
-      activity: "",
-      role: "",
-      technology: "",
-      time: "00:00:00",
-      executionState: "unitialized",
-    },
-  ],
+  data: [],
+};
+
+export type CarouselType = {
+  data: CardType[];
+  selectedCard: CardType | undefined;
+  selectedCardIndex: number;
 };
 
 export default function execution(prevState = initialState, action: any) {
@@ -35,7 +34,7 @@ export default function execution(prevState = initialState, action: any) {
       console.warn("AHAAM", updatedData);
       return {
         data: updatedData,
-        selectedCard: updatedData[0],
+        selectedCard: undefined,
         selectedCardIndex: 0,
       };
     case "SET_CARD_EXECUTION_STATE": {

--- a/src/store/reducers/execution.ts
+++ b/src/store/reducers/execution.ts
@@ -30,7 +30,6 @@ export default function execution(prevState = initialState, action: any) {
     case "REMOVE_CARD":
       const nextCard = prevState.data.length > 0 && action.index === 0 ? 1 : 0;
       return {
-        ...prevState,
         data: prevState.data.filter((item, index) => index !== action.index),
         selectedCard: prevState.data[nextCard],
         selectedCardIndex: 0,

--- a/src/store/reducers/execution.ts
+++ b/src/store/reducers/execution.ts
@@ -20,6 +20,7 @@ const initialState = {
 };
 
 export default function execution(prevState = initialState, action: any) {
+  let updatedData;
   switch (action.type) {
     case "ADD_CARD":
       return {
@@ -28,8 +29,17 @@ export default function execution(prevState = initialState, action: any) {
         selectedCard: action.cards[0],
         selectedCardIndex: 0,
       };
+    case "REMOVE_CARD":
+      updatedData = prevState.data;
+      updatedData.splice(action.index, 1);
+      console.warn("AHAAM", updatedData);
+      return {
+        data: updatedData,
+        selectedCard: updatedData[0],
+        selectedCardIndex: 0,
+      };
     case "SET_CARD_EXECUTION_STATE": {
-      let updatedData = { ...prevState };
+      updatedData = { ...prevState };
       console.warn("AQUI ", updatedData.data[action.index]);
       updatedData.data[action.index].executionState = action.newExecState;
       console.warn("AQUI ", updatedData);

--- a/src/store/reducers/index.ts
+++ b/src/store/reducers/index.ts
@@ -1,0 +1,8 @@
+import { combineReducers } from "redux";
+
+import execution from "./execution";
+
+export default combineReducers({
+  execution,
+  // Adicionar novo reducer aqui, se necessário.
+});


### PR DESCRIPTION
# [04] Integrar cronometro aos botões da tela de execução.

** Obs.: Fazer o merge de https://github.com/2020-1-DTool/dTool/pull/25 antes deste PR.


O que eu fiz foi evitar os seguintes problemas:
- [Estado 2] - não pode zerar o cronômetro antes de confirmar o cancelamento;
- [Estado 3] - não pode zerar o cronômetro quando retomar;

**Autores:** Bianca e Eduardo.

## Checklist

- ✅ funciona em Android
- 🤷‍♀️ (opcional) funciona em iOS
- ✅ interface funciona nos tamanhos de tela suportados (testar em AVD Tablet/Celular)
- ✅ interface segue especificação no Figma
- 🤷‍♀️ passa nos testes funcionais definidos para a tarefa/story
- 🤷‍♀️ documentação atualizada
- ✅ código dentro dos padrões
- ✅ código sem warnings ou erros de linter (rode `npm run lint -- --fix` para ajustar e faça o commit)
- ✅/⚠️/❌/🤷‍♀️ adiciona dependências externas (✅/⚠️/❌/🤷‍♀️ aprovadas pelos AGES III)

Legenda:

- ✅: sim (funciona/builda/documentação atualizada/...)
- ⚠️: parcialmente (partes não funcionam/apenas documentação pendente/...)
- ❌: não (não builda/não funciona/não segue padrões/sem documentação/...)
- 🤷‍♀️: não se aplica (não tenho como testar no iOS/não envolve interface/...)

## Adicione um screenshot/gif da aplicação após último commit, que seja possível visualizar a alteração

Opcional, mas recomendado.

## Outras informações

Comentários extras...
