### PR TITLE
Ajuste - Adiciona endDate a execucao finalizada e enviada para backend

### DIFF
--- a/src/services/appService.ts
+++ b/src/services/appService.ts
@@ -172,6 +172,7 @@ const uploadExecutions = async (): Promise<void> => {
       activityId: execution.activity,
       roleId: execution.role,
       timestamp: moment(execution.date).toISOString(true),
+      endDate: moment(execution.endDate).toISOString(true),
       duration: execution.duration,
     };
   });

--- a/src/services/timerFunction.ts
+++ b/src/services/timerFunction.ts
@@ -164,6 +164,7 @@ export const finishExecution = async (index: number) => {
       role: execution.role,
       date: execution.startTime,
       duration: execution.elapsedTime,
+      endDate: moment().format("YYYY-MM-DDTHH:mm:ssZZ"),
     };
 
     await addFinishedExecution(newFinishedExecution);

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -55,6 +55,7 @@ export type FinishedExecution = {
   role: number;
   date: string; // ISO8601
   duration: number;
+  endDate: string;
 };
 
 export interface LocalData {


### PR DESCRIPTION
# Horário de finalização da contagem de tempo

Quando o usuário clicar em salvar e enviar contagem de tempo, deve ser coletado data e hora da finalização, da mesma forma que fazemos ao iniciar.

**Autores:** Micael Fischmann

## Checklist

- ✅ funciona em Android
- 🤷‍♀️ (opcional) funciona em iOS
- 🤷‍♀️ interface funciona nos tamanhos de tela suportados (testar em AVD Tablet/Celular)
- 🤷‍♀️ interface segue especificação no Figma
- ✅ passa nos testes funcionais definidos para a tarefa/story
- 🤷‍♀️ documentação atualizada
- ✅ código dentro dos padrões
- ✅ código sem warnings ou erros de linter (rode `npm run lint -- --fix` para ajustar e faça o commit)
- 🤷‍♀️ adiciona dependências externas (✅/⚠️/❌/🤷‍♀️ aprovadas pelos AGES III)

Legenda:

- ✅: sim (funciona/builda/documentação atualizada/...)
- ⚠️: parcialmente (partes não funcionam/apenas documentação pendente/...)
- ❌: não (não builda/não funciona/não segue padrões/sem documentação/...)
- 🤷‍♀️: não se aplica (não tenho como testar no iOS/não envolve interface/...)

## Outras informações

Data e hora da finalização adicionada à estrutura que é enviada para Backend. Modificações no Backend incluindo no banco de dados são necessárias para completar a tarefa.
